### PR TITLE
docs: clarify GeoIP refresh compatibility

### DIFF
--- a/clickhouse-gateway/README.md
+++ b/clickhouse-gateway/README.md
@@ -93,6 +93,8 @@ GeoIP 不再从现场华为云、OBS 或业务 CDN 下载。模板固定使用�
 
 版本、大小、校验值、授权与归属见 [GeoIP 数据声明](vector/geoip/NOTICE.md)。更新时必须发布新的月份资产并修改 manifest 中的文件名、URL 和 SHA-256；禁止使用 `latest`。DB-IP City Lite 使用 CC BY 4.0，Dashboard 中的 `IP Geolocation by DB-IP` 链接必须保留。
 
+只改 URL 不会更新已通过旧 SHA 校验的本地文件。文件名也不代表 MMDB metadata 中的真实数据库类型；变更数据提供方时必须同步核对 `type: mmdb` 和 VRL 嵌套字段映射，详细门禁见运行手册。
+
 ## 4. 创建 Vector Secret
 
 Vector 通过 directory secret backend 读取凭据，密码不会进入 ConfigMap 或进程环境：

--- a/docs/vector-clickhouse-gateway-runbook.md
+++ b/docs/vector-clickhouse-gateway-runbook.md
@@ -158,6 +158,8 @@ request:
 
 initContainer 只在本地文件缺失或 SHA 不符时下载，先写随机临时文件，校验后 `chmod 0444` 并原子改名。下载失败应阻止 Vector 启动，不能静默回退到未知或未经校验的数据。
 
+仅修改下载 URL 不会触发更新：如果 `target` 仍指向旧文件且旧 `expected` 与本地文件一致，initContainer 会在下载前直接退出。发布新库时必须同时更新目标文件名、URL 和 SHA-256。也不能根据 URL 或文件名判断数据库类型；先读取 MMDB metadata。若从 `GeoLite2-City` 切换到 `DBIP-City-Lite`，Vector 必须从 `type: geoip` 改为 `type: mmdb`，并把扁平的 `city_name`、`region_name`、`country_name` 读取改为 `city.names`、`subdivisions[].names`、`country.names` 和 `location` 嵌套字段。强制覆盖文件但不改这两处配置会导致 Vector 启动失败或地域字段全部为空。
+
 ## 8. Grafana
 
 Grafana 只读账号只能 `SELECT` 所需数据库和 system 元数据。禁止把 ClickHouse 管理账号放入 datasource。默认最近 15 分钟、自动刷新关闭、明细最多 500 行；大范围分析先扩大聚合间隔，不先扩大 ClickHouse 并发。


### PR DESCRIPTION
## Summary

- document why changing a GeoIP download URL alone does not refresh a checksum-matched local file
- require MMDB metadata inspection instead of trusting the asset filename
- record the required Vector `geoip` to `mmdb` and nested-field migration when changing data providers

## Verification

- `bash scripts/validate-configs.sh --static`
- `git diff --check`
- production CCE rollout validated separately with a 15-minute observation window