### PR TITLE
docs: prioritize VVG in repository guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,24 @@
 # VVG 日志收集系统
 
-VVG 是一个高性能的日志收集、存储、查询和可视化仓库，包含两条边界清晰的生产方案：
-
-- `Vector -> VictoriaLogs -> Grafana`：应用原始日志检索、多行日志和 message 条件过滤；
-- `Vector -> ClickHouse -> Grafana`：Gateway 结构化访问日志、QPS/PV/UV、状态码、延迟和多维分析。
-
-当前验证基线：Vector `0.58.0`、VictoriaLogs `v1.52.0`、ClickHouse `26.8.2.7-alpine`、Grafana `13.2.0-ubuntu`、VictoriaLogs datasource `0.31.0`、Grafana ClickHouse datasource `4.5.1`、Business Text `6.3.0`。Grafana 插件采用版本化宿主机 release 目录和只读挂载，与 Grafana 镜像解耦，正式启动不联网安装。
-
-生产升级和故障排查请先阅读 [AI Agent 配置与验收指南](docs/ai-agent-operations-guide.md)。VictoriaLogs 链路使用[采集延迟运行手册](docs/vector-victorialogs-latency-runbook.md)与[查询性能运行手册](docs/grafana-victorialogs-query-performance-runbook.md)；ClickHouse 网关链路使用[独立部署专区](clickhouse-gateway/README.md)和[运行手册](docs/vector-clickhouse-gateway-runbook.md)。
-
-## Gateway 结构化日志分析
-
-`clickhouse-gateway/` 来自经过生产升级、数据副本验证和持续观察的 Gateway 案例，提供单文件 ClickHouse Compose、Kubernetes Vector、月分区表结构、Grafana datasource、DB-IP GeoIP 和完整 65 面板 KubeDoor Gateway Dashboard。模板不会携带现场地址或凭据，并通过 CI 阻止有限重试、无界 system log、非持久 buffer、`latest`、华为云下载链接和真实环境标识回流仓库。
+VVG 是本仓库的核心日志系统，面向应用原始日志检索、Java 多行日志、message 多条件过滤和可视化排障。主链路为：
 
 ```text
-Gateway stdout -> Vector 0.58 -> ClickHouse 26.8 LTS -> Grafana
-                     |               |
-                     |               +-- 月分区 / 紧凑主键 / 30 天业务 TTL
-                     +-- checkpoint / 1 GiB disk buffer / 180 秒可靠重试 / GeoIP
+Vector -> VictoriaLogs -> Grafana
 ```
 
-快速入口：
+核心验证基线：Vector `0.58.0`、VictoriaLogs `v1.52.0`、Grafana `13.2.0-ubuntu`、VictoriaLogs datasource `0.31.0`、Business Text `6.3.0`。Grafana 插件采用版本化宿主机 release 目录和只读挂载，与 Grafana 镜像解耦，正式启动不联网安装。
 
-- [Vector -> ClickHouse -> Grafana 部署专区](clickhouse-gateway/README.md)
-- [生产盘点、升级、隔离验证和回滚手册](docs/vector-clickhouse-gateway-runbook.md)
-- [架构决策 ADR-001](docs/decisions/0001-vector-clickhouse-gateway.md)
+仓库后半部分另提供独立的 [Gateway 结构化日志分析附加方案](#附加方案gateway-结构化日志分析)。该方案使用 ClickHouse，不与 VVG 的 VictoriaLogs 原始日志链路混合部署或混合变更。
 
-以下截图来自生产案例的脱敏只读视图，域名、项目名和地址均已替换为示例值：
+## 快速入口
 
-![Gateway ClickHouse 日志分析大屏](docs/images/clickhouse-gateway-overview.png)
+- [快速开始](#快速开始)
+- [生产日志检索大屏配置与导入指南](docs/grafana-victorialogs-log-search-dashboard-guide.md)
+- [查询性能与升级运行手册](docs/grafana-victorialogs-query-performance-runbook.md)
+- [Vector/VictoriaLogs 延迟排查运行手册](docs/vector-victorialogs-latency-runbook.md)
+- [AI Agent 配置、升级与验收指南](docs/ai-agent-operations-guide.md)
 
-## 🏗️ 系统架构
+## VVG 核心架构
 
 ```
 ┌─────────────────────┐    ┌──────────────────────┐     ┌─────────────────────┐
@@ -46,7 +34,7 @@ Gateway stdout -> Vector 0.58 -> ClickHouse 26.8 LTS -> Grafana
          :8686                       :9428                       :3000
 ```
 
-## ✨ 核心特性
+## 核心特性
 
 - **🚀 高性能**: VictoriaLogs 提供极高的写入和查询性能
 - **📦 轻量级**: 相比 ELK 栈，资源占用更少
@@ -59,7 +47,7 @@ Gateway stdout -> Vector 0.58 -> ClickHouse 26.8 LTS -> Grafana
 - **⚡ 查询保护**: 默认 15 分钟、All 展开为 `*`、明细 500 行、输入期间零查询
 - **🔒 可审计插件**: 精确版本、SHA-256、不可变 release、只读挂载和原子回滚
 
-## 🖥️ 界面预览
+## 界面预览
 
 生产与测试共享同一 Dashboard 逻辑。以下截图来自脱敏演示环境，实时计数仅用于展示布局。
 
@@ -69,7 +57,7 @@ Gateway stdout -> Vector 0.58 -> ClickHouse 26.8 LTS -> Grafana
 
 ![VVG message 多条件过滤器](docs/images/vvg-message-filter-builder.png)
 
-## 📋 支持的日志格式
+## 支持的日志格式
 
 ### Nginx 日志
 - **Access Log**: 标准格式和 JSON 格式
@@ -83,7 +71,7 @@ Gateway stdout -> Vector 0.58 -> ClickHouse 26.8 LTS -> Grafana
 - **双层处理**: 容器运行时层 + 应用层多行处理 ⭐
 - **JSON 格式**: 结构化 Java 日志
 
-## 🚀 快速开始
+## 快速开始
 
 本系统支持多种部署方式，可根据实际环境选择合适的部署架构。
 
@@ -211,7 +199,7 @@ Pull Request 和 `main` 分支会通过 GitHub Actions 重复执行完整校验�
 
 已有 Grafana 迁移、隔离验证、Chrome 验收和回滚流程见 [VVG AI Agent 配置、升级与验收指南](docs/ai-agent-operations-guide.md)。
 
-## 📁 项目结构
+## 项目结构
 
 ```
 ├── docker-compose/
@@ -225,7 +213,7 @@ Pull Request 和 `main` 分支会通过 GitHub Actions 重复执行完整校验�
 │   │   └── README.md
 │   └── vector/                     # Docker Vector
 ├── k8s-deployment/                 # Docker CRI / Containerd CRI Vector
-├── clickhouse-gateway/             # Gateway -> Vector -> ClickHouse -> Grafana 专区
+├── clickhouse-gateway/             # 附加方案：Gateway -> Vector -> ClickHouse -> Grafana
 │   ├── clickhouse/                 # 单文件 Compose、TTL 和表结构
 │   ├── vector/                     # containerd Vector DaemonSet
 │   └── grafana/                    # datasource 与 Dashboard
@@ -243,7 +231,7 @@ Pull Request 和 `main` 分支会通过 GitHub Actions 重复执行完整校验�
 └── README.md
 ```
 
-## ⚙️ 配置说明
+## 配置说明
 
 ### 环境变量配置
 
@@ -262,7 +250,7 @@ Pull Request 和 `main` 分支会通过 GitHub Actions 重复执行完整校验�
 - Kubernetes 环境中 Vector 能访问 VictoriaLogs 服务
 - 配置正确的防火墙规则
 
-## 🔧 自定义配置
+## 自定义配置
 
 ### 日志格式定制
 
@@ -293,27 +281,59 @@ Pull Request 和 `main` 分支会通过 GitHub Actions 重复执行完整校验�
   - 保留真实事件时间，不使用 `rewrite_timestamp` 掩盖积压
 - **Grafana**: Explore 默认15分钟、最多500行、60秒数据源超时
 
-## 📖 文档
+## VVG 主系统文档
 
-- [故障排查指南](docs/troubleshooting.md)
-- [Vector/VictoriaLogs 延迟排查与升级运行手册](docs/vector-victorialogs-latency-runbook.md)
+使用与排障：
+
+- [生产日志检索大屏配置与导入指南](docs/grafana-victorialogs-log-search-dashboard-guide.md)
 - [Grafana/VictoriaLogs 查询性能与升级运行手册](docs/grafana-victorialogs-query-performance-runbook.md)
-- [VictoriaLogs 部署说明](docker-compose/victorialogs/README.md)
-- [Grafana 部署说明](docker-compose/grafana/README.md)  
-- [Vector 部署说明](docker-compose/vector/README.md)
-- [Kubernetes 部署说明](k8s-deployment/README.md) ⭐
-- [Gateway ClickHouse 完整方案](clickhouse-gateway/README.md)
-- [Vector/ClickHouse/Grafana 运行手册](docs/vector-clickhouse-gateway-runbook.md)
+- [Vector/VictoriaLogs 延迟排查与升级运行手册](docs/vector-victorialogs-latency-runbook.md)
+- [故障排查指南](docs/troubleshooting.md)
+- [AI Agent 配置、升级与验收指南](docs/ai-agent-operations-guide.md)
 
-## 🤝 贡献
+部署说明：
+
+- [VictoriaLogs 部署说明](docker-compose/victorialogs/README.md)
+- [Grafana 部署说明](docker-compose/grafana/README.md)
+- [Vector 部署说明](docker-compose/vector/README.md)
+- [Kubernetes 部署说明](k8s-deployment/README.md)
+
+字段模板参考：
+
+- [研发现场日志查询与过滤参考](docs/grafana-victorialogs-研发现场日志查询%20&%20过滤手册.md)：包含可选结构化字段示例，使用前应按当前日志字段核对。
+
+## 附加方案：Gateway 结构化日志分析
+
+`clickhouse-gateway/` 是独立的 Gateway 访问日志方案，提供单文件 ClickHouse Compose、Kubernetes Vector、月分区表结构、Grafana datasource、DB-IP GeoIP 和完整 65 面板 KubeDoor Gateway Dashboard。当前附加方案基线为 ClickHouse `26.8.2.7-alpine` 和 Grafana ClickHouse datasource `4.5.1`。
+
+该模板不会携带现场地址或凭据，并通过 CI 阻止有限重试、无界 system log、非持久 buffer、`latest`、华为云下载链接和真实环境标识回流仓库。
+
+```text
+Gateway stdout -> Vector 0.58 -> ClickHouse 26.8 LTS -> Grafana
+                     |               |
+                     |               +-- 月分区 / 紧凑主键 / 30 天业务 TTL
+                     +-- checkpoint / 1 GiB disk buffer / 180 秒可靠重试 / GeoIP
+```
+
+附加方案文档：
+
+- [Vector -> ClickHouse -> Grafana 部署专区](clickhouse-gateway/README.md)
+- [生产盘点、升级、隔离验证和回滚手册](docs/vector-clickhouse-gateway-runbook.md)
+- [架构决策 ADR-001](docs/decisions/0001-vector-clickhouse-gateway.md)
+
+以下截图来自生产案例的脱敏只读视图，域名、项目名和地址均已替换为示例值：
+
+![Gateway ClickHouse 日志分析大屏](docs/images/clickhouse-gateway-overview.png)
+
+## 贡献
 
 欢迎提交 Issue 和 Pull Request！
 
-## 📄 许可证
+## 许可证
 
 本项目采用 [MIT 许可证](LICENSE)。
 
-## 🔗 相关链接
+## 相关链接
 
 - [VictoriaLogs 官方文档](https://docs.victoriametrics.com/VictoriaLogs/)
 - [Vector 官方文档](https://vector.dev/docs/)

--- a/docs/ai-agent-operations-guide.md
+++ b/docs/ai-agent-operations-guide.md
@@ -4,16 +4,23 @@
 
 ## 1. 快速定位
 
+### VVG 主系统
+
 | 任务 | 首要文件 |
 | --- | --- |
 | Grafana 与外置插件 | `docker-compose/grafana/README.md`、`scripts/install-grafana-plugins.sh` |
 | 日志检索 Dashboard | `scripts/render-vvg-message-filter.mjs`、`docker-compose/grafana/dashboards/vvg-log-search.json` |
 | 查询慢或页面转圈 | `docs/grafana-victorialogs-query-performance-runbook.md` |
 | Vector 延迟或丢日志 | `docs/vector-victorialogs-latency-runbook.md` |
-| Gateway 日志写入 ClickHouse | `clickhouse-gateway/README.md`、`docs/vector-clickhouse-gateway-runbook.md` |
-| KubeDoor Gateway Dashboard / GeoIP | `scripts/sanitize-clickhouse-gateway-dashboard.mjs`、`clickhouse-gateway/vector/geoip/NOTICE.md` |
 | 字段、导入、回滚 | `docs/grafana-victorialogs-log-search-dashboard-guide.md` |
 | 全仓库约束 | `AGENTS.md`、`scripts/validate-configs.sh` |
+
+### 附加 Gateway 方案
+
+| 任务 | 首要文件 |
+| --- | --- |
+| Gateway 日志写入 ClickHouse | `clickhouse-gateway/README.md`、`docs/vector-clickhouse-gateway-runbook.md` |
+| KubeDoor Gateway Dashboard / GeoIP | `scripts/sanitize-clickhouse-gateway-dashboard.mjs`、`clickhouse-gateway/vector/geoip/NOTICE.md` |
 
 ## 2. 先判断任务边界
 

--- a/docs/grafana-victorialogs-研发现场日志查询 & 过滤手册.md
+++ b/docs/grafana-victorialogs-研发现场日志查询 & 过滤手册.md
@@ -1,8 +1,9 @@
-# Grafana × VictoriaLogs
-# 研发现场日志查询 & 过滤手册（可直接替换使用）
+# Grafana × VictoriaLogs 研发现场日志查询与过滤参考
 
 > 适用：Grafana **Explore** 页面或面板，数据源选择 **VictoriaLogs**。  
-> 目标：研发同学**快速定位问题**，把查询直接复制替换即可用。
+> 目标：为研发现场排障提供查询模板；复制前必须按当前日志字段和 LogsQL 版本核对。
+
+当前 VVG 生产 Dashboard 的字段契约是 `namespace`、`container`、`pod`、`level` 和 `message`，以[生产日志检索大屏配置与导入指南](grafana-victorialogs-log-search-dashboard-guide.md)为准。本文中的 `status`、`path`、`responsetime_ms` 等属于可选结构化字段；未在 Vector 侧生成这些字段时，对应示例不可直接使用。Gateway 结构化访问日志请使用独立的 [ClickHouse Gateway 方案](../clickhouse-gateway/README.md)。
 
 ---
 

--- a/scripts/validate-configs.sh
+++ b/scripts/validate-configs.sh
@@ -97,6 +97,22 @@ validate_static() {
     "README displays the message filter builder"
   require_literal "README.md" 'docs/ai-agent-operations-guide.md' \
     "README links the AI agent operations guide"
+  require_literal "README.md" 'docs/grafana-victorialogs-研发现场日志查询%20&%20过滤手册.md' \
+    "README links the developer query quick reference"
+  local readme_core_line
+  local readme_docs_line
+  local readme_gateway_line
+  readme_core_line="$(grep -nF '## VVG 核心架构' README.md | head -n 1 | cut -d: -f1)"
+  readme_docs_line="$(grep -nF '## VVG 主系统文档' README.md | head -n 1 | cut -d: -f1)"
+  readme_gateway_line="$(grep -nF '## 附加方案：Gateway 结构化日志分析' README.md | head -n 1 | cut -d: -f1)"
+  if [[ -n "${readme_core_line}" && -n "${readme_docs_line}" \
+      && -n "${readme_gateway_line}" \
+      && "${readme_core_line}" -lt "${readme_gateway_line}" \
+      && "${readme_docs_line}" -lt "${readme_gateway_line}" ]]; then
+    pass "README prioritizes the VVG log system before the Gateway add-on"
+  else
+    fail "README must place VVG architecture and documentation before the Gateway add-on"
+  fi
   tracked_sensitive="$(git ls-files | grep -E '(^|/)(\.env|服务器信息\.txt)$' || true)"
   if [[ -n "${tracked_sensitive}" ]]; then
     printf '%s\n' "${tracked_sensitive}" >&2


### PR DESCRIPTION
## Summary
- make the VVG `Vector -> VictoriaLogs -> Grafana` system the first and complete README narrative
- move the detailed ClickHouse Gateway content behind VVG architecture, deployment, configuration, and documentation
- split documentation navigation into VVG primary guides and the independent Gateway add-on
- separate the AI operations quick index into primary VVG and add-on Gateway sections
- clarify that the developer query reference contains optional field templates and has one canonical H1
- add a CI guard that prevents Gateway content from moving ahead of VVG architecture and documentation

## Documentation value analysis
- preserved all deployment, validation, troubleshooting, screenshots, add-on links, and historical plans
- did not merge or delete runbooks because they have distinct operational ownership
- surfaced the canonical Dashboard and query-performance guides before optional field templates
- removed decorative heading emoji so local navigation anchors remain stable

## Validation
- full repository static configuration validation with Git for Windows Bash
- README relative-link and local-anchor checks
- Markdown heading check outside fenced code blocks
- `git diff --check`
- tracked-credential and added-address/secret scans

## Scope
Documentation and its structural CI guard only. No runtime configuration or live environment changes.