### PR TITLE
feat: add guarded VictoriaLogs MCP deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ clickhouse-gateway/clickhouse/data/
 clickhouse-gateway/clickhouse/logs/
 clickhouse-gateway/**/secret.yaml
 clickhouse-gateway/vector/geoip/*.mmdb
+docker-compose/mcp-victorialogs/vmauth/auth.yml
+docker-compose/mcp-victorialogs/secrets/
+**/client-bearer-token
 
 # Local PR drafting artifact
 PR_BODY.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@
 4. `docs/grafana-victorialogs-query-performance-runbook.md`
 5. `docs/grafana-victorialogs-log-search-dashboard-guide.md`
 6. ClickHouse 网关链路任务再读 `docs/vector-clickhouse-gateway-runbook.md`
-7. 即将修改的 Compose、环境变量示例、Dashboard 生成器和校验脚本
+7. MCP 任务再读 `docker-compose/mcp-victorialogs/README.md`
+8. 即将修改的 Compose、环境变量示例、Dashboard 生成器和校验脚本
 
 ## 不可破坏的基线
 
@@ -23,6 +24,18 @@
 - 测试和生产使用同一查询逻辑、面板代码、颜色和限制；只允许标题、集群显示名、环境标签和默认 namespace 不同。
 - 只改获批服务。Grafana 变更不得顺带升级 VictoriaLogs、Vector 或业务服务。
 - ClickHouse 网关链路固定 Dashboard UID `vvg-clickhouse-gateway` 和 datasource UID `gateway-clickhouse`；默认最近 15 分钟、自动刷新关闭、明细 500 行。
+
+## VictoriaLogs MCP 专区
+
+`docker-compose/mcp-victorialogs/` 使用官方 `mcp-victorialogs` 和官方 `vmauth`，不得复制实现 VictoriaLogs 查询 API 或自建另一套 MCP 协议服务。
+
+- 测试和生产使用同一镜像 digest、工具集合、资源限制和查询保护，但必须部署两个实例并固定各自 VictoriaLogs 地址、租户和独立 Token；禁止用客户端 Header 或参数切换环境。
+- 只暴露 `vmauth`。MCP 容器不得直接发布宿主机端口，`MCP_PASSTHROUGH_HEADERS` 必须保持未设置。
+- 外部 MCP 请求必须使用独立 Bearer Token。MCP 到 VictoriaLogs 的内部 Token 与外部 Token 不得复用。
+- 只开放 `query`、`hits`、`field_names`、`field_values` 和 `stats_query`。日志查询最多 500 行，字段值最多 100，后端超时不超过 20 秒，MCP 后端查询并发固定为 1。
+- `AccountID` 和 `ProjectID` 必须由 `vmauth` 覆盖，禁止信任工具参数中的租户值；只允许批准的 `/select/logsql/*` 路径，禁止写入、管理、flags 和 metrics 路径代理到 VictoriaLogs。
+- 主机部署目录固定为 `/data/vvg-mcp`。`.env`、`vmauth/auth.yml` 和 `secrets/client-bearer-token` 必须留在目标机、限制权限并被 Git 忽略。
+- 单文件 bind mount 通过原子替换更新后必须只重建 `vmauth`，不能假定 HUP 会切换到新 inode。
 
 ## Vector -> ClickHouse -> Grafana 专区
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ VVG 是本仓库的核心日志系统，面向应用原始日志检索、Java �
 Vector -> VictoriaLogs -> Grafana
 ```
 
-核心验证基线：Vector `0.58.0`、VictoriaLogs `v1.52.0`、Grafana `13.2.0-ubuntu`、VictoriaLogs datasource `0.31.0`、Business Text `6.3.0`。Grafana 插件采用版本化宿主机 release 目录和只读挂载，与 Grafana 镜像解耦，正式启动不联网安装。
+面向 AI Agent 的受控只读查询链路为：
+
+```text
+MCP Client -> mcp-victorialogs -> vmauth -> VictoriaLogs
+```
+
+核心验证基线：Vector `0.58.0`、VictoriaLogs `v1.52.0`、Grafana `13.2.0-ubuntu`、VictoriaLogs datasource `0.31.0`、Business Text `6.3.0`、VictoriaLogs MCP `v1.9.0`、vmauth `v1.151.0`。Grafana 插件采用版本化宿主机 release 目录和只读挂载，与 Grafana 镜像解耦，正式启动不联网安装。
 
 仓库后半部分另提供独立的 [Gateway 结构化日志分析附加方案](#附加方案gateway-结构化日志分析)。该方案使用 ClickHouse，不与 VVG 的 VictoriaLogs 原始日志链路混合部署或混合变更。
 
@@ -17,6 +23,7 @@ Vector -> VictoriaLogs -> Grafana
 - [查询性能与升级运行手册](docs/grafana-victorialogs-query-performance-runbook.md)
 - [Vector/VictoriaLogs 延迟排查运行手册](docs/vector-victorialogs-latency-runbook.md)
 - [AI Agent 配置、升级与验收指南](docs/ai-agent-operations-guide.md)
+- [VictoriaLogs MCP 部署说明](docker-compose/mcp-victorialogs/README.md)
 
 ## VVG 核心架构
 
@@ -122,7 +129,21 @@ docker compose --env-file .env up -d
 
 详细说明: [Grafana 部署文档](docker-compose/grafana/README.md)
 
-#### 3. 部署 Vector (日志收集)
+#### 3. 部署 VictoriaLogs MCP（可选）
+
+MCP 使用独立 Compose 项目，不重建 Grafana、VictoriaLogs 或 Vector。测试和生产分别部署，临时内网入口为 `http://HOST:8081/mcp`，并强制 Bearer Token。
+
+```bash
+cd docker-compose/mcp-victorialogs
+cp env.example .env
+# 将官方固定镜像镜像到私库，渲染独立 Token 和 vmauth/auth.yml
+docker compose --env-file .env config --quiet
+docker compose --env-file .env up -d
+```
+
+详细说明：[VictoriaLogs MCP 部署文档](docker-compose/mcp-victorialogs/README.md)
+
+#### 4. 部署 Vector (日志收集)
 
 在每台需要收集日志的应用服务器上:
 
@@ -136,7 +157,7 @@ docker-compose up -d
 
 详细说明: [Vector 部署文档](docker-compose/vector/README.md)
 
-#### 4. Kubernetes 部署 (可选) ⭐
+#### 5. Kubernetes 部署 (可选) ⭐
 
 在 Kubernetes 环境中部署 Vector 进行日志收集:
 
@@ -211,6 +232,7 @@ Pull Request 和 `main` 分支会通过 GitHub Actions 重复执行完整校验�
 │   │   ├── docker-compose.yml
 │   │   ├── env.example
 │   │   └── README.md
+│   ├── mcp-victorialogs/           # 官方 MCP + vmauth 查询保护
 │   └── vector/                     # Docker Vector
 ├── k8s-deployment/                 # Docker CRI / Containerd CRI Vector
 ├── clickhouse-gateway/             # 附加方案：Gateway -> Vector -> ClickHouse -> Grafana
@@ -295,6 +317,7 @@ Pull Request 和 `main` 分支会通过 GitHub Actions 重复执行完整校验�
 
 - [VictoriaLogs 部署说明](docker-compose/victorialogs/README.md)
 - [Grafana 部署说明](docker-compose/grafana/README.md)
+- [VictoriaLogs MCP 部署说明](docker-compose/mcp-victorialogs/README.md)
 - [Vector 部署说明](docker-compose/vector/README.md)
 - [Kubernetes 部署说明](k8s-deployment/README.md)
 

--- a/docker-compose/mcp-victorialogs/README.md
+++ b/docker-compose/mcp-victorialogs/README.md
@@ -1,0 +1,72 @@
+# VictoriaLogs MCP
+
+This directory deploys the official VictoriaLogs MCP server behind the official
+`vmauth` proxy. It is a read-only, separately deployable addition to the VVG
+stack and does not require rebuilding Grafana, VictoriaLogs, or Vector.
+
+## Security model
+
+- Deploy one instance per environment. Do not route test and production through
+  a client-controlled header or tool argument.
+- Expose only `vmauth`; the MCP container remains on an internal Docker network.
+- Require a distinct random bearer token for every environment.
+- `vmauth` fixes the VictoriaLogs tenant, allows only approved `/select/logsql`
+  paths, clamps log responses to 500 rows, limits field discovery to 100 values,
+  applies backend timeouts, and permits one MCP query at a time.
+- The client bearer token and the MCP-to-vmauth token must be different.
+- Keep `.env`, `vmauth/auth.yml`, access tokens, server addresses, and runtime
+  data out of Git. Both deployed files must be mode `0600`; the mounted auth
+  file may be changed to `0640` with group `65534` for the non-root proxy.
+- Leave `MCP_PASSTHROUGH_HEADERS` unset. In particular, do not forward the
+  caller's `Authorization` header to VictoriaLogs.
+
+## Host layout
+
+```text
+/data/vvg-mcp/
+  docker-compose.yml
+  .env
+  vmauth/
+    auth.yml
+  secrets/
+    client-bearer-token
+  backups/
+```
+
+The services are stateless. No application data volume is required. Runtime
+logs use bounded Docker `json-file` rotation. The `secrets/` and `backups/`
+directories remain under the deployment directory so the whole service has a
+single ownership boundary.
+
+## Deployment
+
+1. Resolve the current approved upstream release and mirror its exact
+   architecture digest into the private registry.
+2. Copy `env.example` to `.env`, use private-registry image references including
+   digest, and generate two independent random bearer tokens.
+3. Render `vmauth/auth.yml` from `vmauth/auth.example.yml` with the fixed
+   environment-specific VictoriaLogs URL and tenant.
+4. Validate with the target host's actual Compose binary:
+
+   ```bash
+   docker run --rm \
+     -v "$PWD/vmauth/auth.yml:/etc/vmauth/auth.yml:ro" \
+     "$VMAUTH_IMAGE" \
+     -auth.config=/etc/vmauth/auth.yml -dryRun
+
+   docker-compose --env-file .env config -q
+   ```
+
+5. Start only this project, then verify both containers, unauthenticated
+   rejection, authenticated MCP initialization, tool listing, a 15-minute real
+   query, backend concurrency, restart count, OOM state, and existing Grafana
+   and VictoriaLogs health.
+
+When replacing `vmauth/auth.yml` atomically on the host, recreate only the
+`vmauth` service. A bind-mounted file remains attached to the old inode, so a
+HUP reload alone may continue reading the previous file. An in-place update can
+use HUP, but atomic replacement plus a targeted recreate is the safer rollout.
+
+Use `http://HOST:MCP_PORT/mcp` as the temporary private-network endpoint. A
+later HTTPS reverse proxy must preserve streamable HTTP request headers and
+timeouts, authenticate callers, and keep the direct host port private.

--- a/docker-compose/mcp-victorialogs/docker-compose.yml
+++ b/docker-compose/mcp-victorialogs/docker-compose.yml
@@ -1,0 +1,96 @@
+version: "2.4"
+
+services:
+  vmauth:
+    image: ${VMAUTH_IMAGE}
+    container_name: vvg-mcp-vmauth
+    restart: always
+    user: "65534:65534"
+    command:
+      - -auth.config=/etc/vmauth/auth.yml
+      - -httpListenAddr=:8427
+      - -httpInternalListenAddr=:8428
+      - -maxConcurrentRequests=8
+      - -maxConcurrentPerUserRequests=4
+      - -maxQueueDuration=2s
+      - -loggerFormat=json
+      - -loggerOutput=stderr
+    ports:
+      - "${MCP_BIND_ADDRESS}:${MCP_PORT}:8427"
+    volumes:
+      - ./vmauth/auth.yml:/etc/vmauth/auth.yml:ro
+    networks:
+      - edge
+      - backend
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=16m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 128m
+    cpus: 0.25
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -T 3 -O /dev/null http://127.0.0.1:8428/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 4
+      start_period: 10s
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
+
+  mcp-victorialogs:
+    image: ${MCP_VICTORIALOGS_IMAGE}
+    container_name: vvg-mcp-victorialogs
+    restart: always
+    depends_on:
+      vmauth:
+        condition: service_healthy
+    environment:
+      VL_INSTANCE_ENTRYPOINT: http://vvg-mcp-vmauth:8427
+      VL_INSTANCE_BEARER_TOKEN: ${VL_PROXY_BEARER_TOKEN}
+      VL_DEFAULT_TENANT_ID: ${VL_DEFAULT_TENANT_ID}
+      MCP_SERVER_MODE: http
+      MCP_LISTEN_ADDR: 0.0.0.0:8081
+      MCP_DISABLED_TOOLS: documentation,flags,facets,streams,stream_ids,stream_field_names,stream_field_values,stats_query_range
+      MCP_HEARTBEAT_INTERVAL: 30s
+      MCP_LOG_FORMAT: json
+      MCP_LOG_LEVEL: info
+    expose:
+      - "8081"
+    networks:
+      - backend
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=32m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 256m
+    cpus: 0.50
+    stop_grace_period: 30s
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -T 3 -O /dev/null http://127.0.0.1:8081/health/readiness"]
+      interval: 15s
+      timeout: 5s
+      retries: 4
+      start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
+
+networks:
+  edge:
+    driver: bridge
+  backend:
+    driver: bridge
+    internal: true

--- a/docker-compose/mcp-victorialogs/env.example
+++ b/docker-compose/mcp-victorialogs/env.example
@@ -1,0 +1,14 @@
+# Copy to .env on the target host and keep it mode 0600.
+MCP_BIND_ADDRESS=0.0.0.0
+MCP_PORT=8081
+
+# These are the validated upstream Linux AMD64 manifests. Mirror them into the
+# approved private registry and use the digest returned by that registry in the
+# deployed .env.
+MCP_VICTORIALOGS_IMAGE=ghcr.io/victoriametrics/mcp-victorialogs:v1.9.0@sha256:af6afb6e36f3678e9d5096d155372a33b8c3e45e9a5de756129c6e5628dbff9d
+VMAUTH_IMAGE=quay.io/victoriametrics/vmauth:v1.151.0@sha256:047f7bdccff16df457db488e0e1fbc5b3fd15470c5b5ff5fa38a85d4d6bd71df
+
+# This credential is generated independently on each host and is used only
+# between mcp-victorialogs and vmauth. Never commit the deployed value.
+VL_PROXY_BEARER_TOKEN=CHANGE_ME_BEFORE_DEPLOY
+VL_DEFAULT_TENANT_ID=0:0

--- a/docker-compose/mcp-victorialogs/vmauth/auth.example.yml
+++ b/docker-compose/mcp-victorialogs/vmauth/auth.example.yml
@@ -1,0 +1,52 @@
+users:
+  - name: vvg-mcp-client
+    bearer_token: "__MCP_CLIENT_BEARER_TOKEN__"
+    max_concurrent_requests: 4
+    url_map:
+      - src_paths:
+          - "/mcp"
+        url_prefix:
+          - "http://mcp-victorialogs:8081"
+
+  - name: vvg-mcp-backend
+    bearer_token: "__VL_PROXY_BEARER_TOKEN__"
+    max_concurrent_requests: 1
+    headers:
+      - "AccountID: __VL_ACCOUNT_ID__"
+      - "ProjectID: __VL_PROJECT_ID__"
+    url_map:
+      # Preserve requests up to 500 rows; clamp missing or larger limits to 500.
+      - src_paths:
+          - "/select/logsql/query"
+        src_query_args:
+          - "limit=~([1-9]|[1-9][0-9]|[1-4][0-9][0-9]|500)"
+        url_prefix:
+          - "__VICTORIALOGS_URL__/?timeout=20s"
+      - src_paths:
+          - "/select/logsql/query"
+        url_prefix:
+          - "__VICTORIALOGS_URL__/?limit=500&timeout=20s"
+      - src_paths:
+          - "/select/logsql/hits"
+        url_prefix:
+          - "__VICTORIALOGS_URL__/?fields_limit=20&timeout=20s"
+      - src_paths:
+          - "/select/logsql/stats_query"
+        url_prefix:
+          - "__VICTORIALOGS_URL__/?timeout=20s"
+      - src_paths:
+          - "/select/logsql/field_names"
+        url_prefix:
+          - "__VICTORIALOGS_URL__/?limit=100&timeout=15s"
+      - src_paths:
+          - "/select/logsql/field_values"
+        url_prefix:
+          - "__VICTORIALOGS_URL__/?limit=100&timeout=15s"
+
+unauthorized_user:
+  url_map:
+    - src_paths:
+        - "/health/liveness"
+        - "/health/readiness"
+      url_prefix:
+        - "http://mcp-victorialogs:8081"

--- a/scripts/validate-configs.sh
+++ b/scripts/validate-configs.sh
@@ -75,6 +75,9 @@ validate_static() {
   local grafana_env="docker-compose/grafana/env.example"
   local grafana_datasource="docker-compose/grafana/datasources/victorialogs.yaml"
   local grafana_dashboard="docker-compose/grafana/dashboards/vvg-log-search.json"
+  local mcp_compose="docker-compose/mcp-victorialogs/docker-compose.yml"
+  local mcp_env="docker-compose/mcp-victorialogs/env.example"
+  local mcp_auth="docker-compose/mcp-victorialogs/vmauth/auth.example.yml"
   local victorialogs_compose="docker-compose/victorialogs/docker-compose.yml"
   local vector_config="docker-compose/vector/vector.yaml"
   local password_value
@@ -91,6 +94,8 @@ validate_static() {
     "Vector ClickHouse Gateway runbook exists"
   require_file "docs/images/vvg-dashboard-overview.png" "Sanitized dashboard overview exists"
   require_file "docs/images/vvg-message-filter-builder.png" "Sanitized message filter screenshot exists"
+  require_file "docker-compose/mcp-victorialogs/README.md" \
+    "VictoriaLogs MCP deployment guide exists"
   require_literal "README.md" 'docs/images/vvg-dashboard-overview.png' \
     "README displays the dashboard overview"
   require_literal "README.md" 'docs/images/vvg-message-filter-builder.png' \
@@ -113,6 +118,8 @@ validate_static() {
   else
     fail "README must place VVG architecture and documentation before the Gateway add-on"
   fi
+  require_literal "README.md" 'docker-compose/mcp-victorialogs/README.md' \
+    "README links the VictoriaLogs MCP deployment guide"
   tracked_sensitive="$(git ls-files | grep -E '(^|/)(\.env|服务器信息\.txt)$' || true)"
   if [[ -n "${tracked_sensitive}" ]]; then
     printf '%s\n' "${tracked_sensitive}" >&2
@@ -260,6 +267,41 @@ validate_static() {
   require_literal "docker-compose/vector/env.example" 'VECTOR_API_BIND=127.0.0.1' \
     "Docker Vector API binds to host loopback by default"
 
+  require_literal "${mcp_compose}" 'version: "2.4"' \
+    "VictoriaLogs MCP Compose stays compatible with the validated legacy host"
+  require_literal "${mcp_env}" 'mcp-victorialogs:v1.9.0@sha256:af6afb6e36f3678e9d5096d155372a33b8c3e45e9a5de756129c6e5628dbff9d' \
+    "VictoriaLogs MCP image uses a pinned release and digest"
+  require_literal "${mcp_env}" 'vmauth:v1.151.0@sha256:047f7bdccff16df457db488e0e1fbc5b3fd15470c5b5ff5fa38a85d4d6bd71df' \
+    "vmauth image uses a pinned release and digest"
+  require_literal "${mcp_compose}" 'MCP_SERVER_MODE: http' \
+    "VictoriaLogs MCP uses streamable HTTP mode"
+  require_literal "${mcp_compose}" 'MCP_DISABLED_TOOLS: documentation,flags,facets,streams,stream_ids,stream_field_names,stream_field_values,stats_query_range' \
+    "VictoriaLogs MCP exposes only the approved read-only tool set"
+  forbid_regex "${mcp_compose}" 'MCP_PASSTHROUGH_HEADERS' \
+    "VictoriaLogs MCP does not pass caller headers upstream"
+  require_literal "${mcp_compose}" 'read_only: true' \
+    "VictoriaLogs MCP services use read-only root filesystems"
+  require_literal "${mcp_compose}" 'mem_limit: 256m' \
+    "VictoriaLogs MCP memory usage is bounded"
+  require_literal "${mcp_auth}" 'max_concurrent_requests: 1' \
+    "VictoriaLogs MCP reserves only one backend query slot"
+  require_literal "${mcp_auth}" 'limit=~([1-9]|[1-9][0-9]|[1-4][0-9][0-9]|500)' \
+    "VictoriaLogs MCP preserves explicit log limits up to 500"
+  require_literal "${mcp_auth}" '?limit=500&timeout=20s' \
+    "VictoriaLogs MCP clamps missing or oversized log limits"
+  require_literal "${mcp_auth}" '?limit=100&timeout=15s' \
+    "VictoriaLogs MCP bounds field discovery"
+  require_literal "${mcp_auth}" 'AccountID: __VL_ACCOUNT_ID__' \
+    "vmauth fixes the VictoriaLogs account tenant"
+  require_literal "${mcp_auth}" 'ProjectID: __VL_PROJECT_ID__' \
+    "vmauth fixes the VictoriaLogs project tenant"
+  forbid_regex "${mcp_auth}" '/(insert|flags|metrics)(/|\")' \
+    "VictoriaLogs MCP proxy exposes no write or administrative backend paths"
+  require_literal ".gitignore" 'docker-compose/mcp-victorialogs/vmauth/auth.yml' \
+    "Rendered vmauth credentials are ignored"
+  require_literal ".gitignore" '**/client-bearer-token' \
+    "MCP client bearer tokens are ignored"
+
   if grep -R -n -E --include='*.yaml' --include='*.yml' \
       'drop_newest|rewrite_timestamp' docker-compose k8s-deployment >/dev/null; then
     fail "Active YAML must not drop newest logs or rewrite event timestamps"
@@ -274,10 +316,11 @@ validate_static() {
     pass "Compose baselines use pinned versions"
   fi
 
-  if grep -n '^version:' docker-compose/*/docker-compose.yml >/dev/null; then
+  if grep -n '^version:' docker-compose/*/docker-compose.yml \
+      | grep -v '^docker-compose/mcp-victorialogs/docker-compose.yml:' >/dev/null; then
     fail "Compose files must not use the obsolete top-level version field"
   else
-    pass "Compose files omit the obsolete top-level version field"
+    pass "Compose files omit the obsolete top-level version field except the validated legacy MCP deployment"
   fi
 
   if bash scripts/validate-clickhouse-gateway.sh --static; then
@@ -333,7 +376,7 @@ validate_runtime() {
   }
   docker compose version
 
-  for component in grafana victorialogs vector; do
+  for component in grafana victorialogs vector mcp-victorialogs; do
     docker compose \
       --env-file "docker-compose/${component}/env.example" \
       -f "docker-compose/${component}/docker-compose.yml" \


### PR DESCRIPTION
## Summary
- add a Docker Compose deployment for the official VictoriaLogs MCP server behind official vmauth
- pin validated upstream Linux AMD64 image digests and document private-registry mirroring
- enforce bearer authentication, fixed tenant headers, approved read-only tools, result limits, timeouts, resource limits, and one backend query slot
- document separate production/test deployments under `/data/vvg-mcp` and protect rendered credentials from Git
- extend repository validation with MCP version, security, limit, and compatibility guards

## Validation
- `bash -n scripts/validate-configs.sh`
- `bash scripts/validate-configs.sh --static`
- `node scripts/validate-vvg-message-filter.mjs`
- `git diff --check origin/main...HEAD`
- secret and environment-address scan passed
- legacy Docker Compose 1.25 target expanded and ran the candidate successfully
- Docker Compose v2 target expanded and ran the candidate successfully
- both environments passed MCP initialize, tools/list, authenticated 15-minute log query, wrong-token rejection, health, resource, restart, and OOM checks
- explicit 2-line requests return 2 lines; oversized requests are clamped to 500
- existing Grafana and VictoriaLogs health remained unchanged

## Operational notes
- live credentials and environment addresses remain only in mode-restricted files on the target hosts
- no Grafana, VictoriaLogs, Vector, ClickHouse, or business container was recreated