### PR TITLE
Support remote VVG consumer placement

### DIFF
--- a/docker-compose/automq/README.md
+++ b/docker-compose/automq/README.md
@@ -84,6 +84,33 @@ docker compose --env-file .env --profile production up -d \
 不能让 shadow 和 production 消费者同时写同一个正式后端。生产 group 首次启动
 必须先于生产者主切，使用 `latest` 建立当前末尾 offset，避免把影子历史重新灌入。
 
+### VVG consumer 跨主机放置
+
+当 VictoriaLogs 与 AutoMQ 位于不同宿主机，且 VictoriaLogs 主机通过资源门禁后，可用
+`docker-compose.vvg-consumers.yml` 将三个 VVG consumer 放到 VictoriaLogs 所在主机，
+减少解压后日志的跨机传输。复制 `vvg-consumers.env.example` 为目标机本地 `.env`，填入
+已验证的镜像 digest、VPC 内 Kafka 地址和 VictoriaLogs 地址；`.env` 与 SCRAM password
+必须保持 `0600` 且不得进入 Git。
+
+三个服务使用同一 production consumer group，但分别使用独立 state 目录和 metrics
+端口。迁移时每次只启动一个新实例，确认 group rebalance、事件收发和错误计数后，再
+优雅停止一个旧实例。Kafka offset 是恢复依据，不复制 Vector memory buffer。AutoMQ、
+Gateway consumer 和 ClickHouse 应继续同机，除非另有独立迁移与回滚方案。
+
+旧实例停止后必须禁用其自动重启策略，避免原宿主机或 Docker daemon 重启时重新加入
+生产 group。验收前可保留已停止容器作为快速回滚入口；回滚时先恢复 `restart: always`
+再逐实例启动。远端放置生效后，日常执行原 AutoMQ Compose 时不得再次启动本地
+`vector-vvg-production` 服务。
+
+目标机使用旧版 Compose 时先运行：
+
+```bash
+docker-compose --env-file .env -f docker-compose.yml config --quiet
+docker image inspect "$(sed -n 's/^VECTOR_IMAGE=//p' .env)"
+```
+
+正式启动必须使用已存在的精确镜像，禁止为完成迁移临时在线拉取。
+
 ## Vector producer 清单
 
 仓库已提交两份由当前公开基线生成的完整 production清单：

--- a/docker-compose/automq/docker-compose.vvg-consumers.yml
+++ b/docker-compose/automq/docker-compose.vvg-consumers.yml
@@ -1,0 +1,70 @@
+x-vector-common: &vector-common
+  image: ${VECTOR_IMAGE}
+  restart: always
+  stop_grace_period: 2m
+  read_only: true
+  command: ["--config", "/etc/vector/vector.yaml"]
+  environment: &vector-environment
+    AUTOMQ_BOOTSTRAP_SERVERS: ${AUTOMQ_BOOTSTRAP_SERVERS}
+    AUTOMQ_TOPIC: ${VVG_TOPIC}
+    AUTOMQ_CONSUMER_GROUP: ${VVG_CONSUMER_GROUP}
+    VICTORIALOGS_URL: ${VICTORIALOGS_URL}
+    VICTORIALOGS_TENANT_ID: ${VICTORIALOGS_TENANT_ID}
+    VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION: "true"
+  volumes:
+    - ./config/vector-vvg-consumer.yaml:/etc/vector/vector.yaml:ro
+    - ./secrets/vvg-consumer:/run/secrets/kafka:ro
+  cpus: 1.0
+  mem_limit: 1536m
+  memswap_limit: 1536m
+  pids_limit: 256
+  tmpfs:
+    - /tmp:size=64m,mode=1777
+  security_opt:
+    - no-new-privileges:true
+  logging:
+    driver: local
+    options:
+      max-size: 20m
+      max-file: "5"
+  networks:
+    - vvg-consumers
+
+services:
+  vector-vvg-production-1:
+    <<: *vector-common
+    container_name: automq-vector-vvg-production-1
+    environment: *vector-environment
+    volumes:
+      - ./config/vector-vvg-consumer.yaml:/etc/vector/vector.yaml:ro
+      - ./secrets/vvg-consumer:/run/secrets/kafka:ro
+      - ./state/vector-vvg-production-1:/var/lib/vector
+    ports:
+      - "${VVG_METRICS_BIND_IP}:19598:9598"
+
+  vector-vvg-production-2:
+    <<: *vector-common
+    container_name: automq-vector-vvg-production-2
+    environment: *vector-environment
+    volumes:
+      - ./config/vector-vvg-consumer.yaml:/etc/vector/vector.yaml:ro
+      - ./secrets/vvg-consumer:/run/secrets/kafka:ro
+      - ./state/vector-vvg-production-2:/var/lib/vector
+    ports:
+      - "${VVG_METRICS_BIND_IP}:19599:9598"
+
+  vector-vvg-production-3:
+    <<: *vector-common
+    container_name: automq-vector-vvg-production-3
+    environment: *vector-environment
+    volumes:
+      - ./config/vector-vvg-consumer.yaml:/etc/vector/vector.yaml:ro
+      - ./secrets/vvg-consumer:/run/secrets/kafka:ro
+      - ./state/vector-vvg-production-3:/var/lib/vector
+    ports:
+      - "${VVG_METRICS_BIND_IP}:19600:9598"
+
+networks:
+  vvg-consumers:
+    name: automq-vvg-consumers
+    driver: bridge

--- a/docker-compose/automq/vvg-consumers.env.example
+++ b/docker-compose/automq/vvg-consumers.env.example
@@ -1,0 +1,7 @@
+VECTOR_IMAGE=timberio/vector@sha256:REPLACE_WITH_VERIFIED_DIGEST
+AUTOMQ_BOOTSTRAP_SERVERS=automq.example.internal:9092
+VVG_TOPIC=vvg.logs.v1
+VVG_CONSUMER_GROUP=vvg-victorialogs-production-v1
+VICTORIALOGS_URL=http://victorialogs.example.internal:9428
+VICTORIALOGS_TENANT_ID=0:0
+VVG_METRICS_BIND_IP=127.0.0.1

--- a/docs/automq-log-buffer-runbook.md
+++ b/docs/automq-log-buffer-runbook.md
@@ -85,6 +85,35 @@ shadow 清单必须满足：
 - Gateway shadow 的 checkpoint 与 GeoIP 数据必须分卷；已校验的正式 GeoIP 目录只读
   复用，不能让 shadow init 容器重新联网下载。
 
+### 4.1 VVG consumer 跨主机迁移
+
+只有 VictoriaLogs 目标机同时满足以下条件时，才允许把 VVG consumer 与 VictoriaLogs
+同机放置：可用内存不少于 3 GiB、连续 10 分钟 CPU低于 80%、无 Swap压力、Kafka VPC
+入口和 VictoriaLogs健康接口可达、精确 Vector image ID/digest已在本机验证。旧 ELK、
+Logstash、Redis等服务未获单独批准时不得停止或重建。
+
+使用 `docker-compose/automq/docker-compose.vvg-consumers.yml` 部署三个显式服务。它们
+必须保留原 production Topic/group、1 CPU/1.5 GiB限制、120 秒优雅停止、memory+block、
+acknowledgement和相同 Vector配置；三个 state目录及 metrics端口必须彼此独立。目标机
+`.env`、SCRAM password和备份保持 `0600`，真实地址不得写入仓库。
+
+主切按以下顺序逐实例执行：
+
+1. 启动一个目标机 consumer，确认 group成员增加、metrics可抓取、收到和发出事件、
+   `vector_component_errors_total`无增长；
+2. 在原主机用 `docker stop -t 120` 停止一个 consumer，确认退出码 0且 group恢复为三个
+   成员；
+3. 重复两次，期间持续观察 lag；不允许一次停止全部旧 consumer；
+4. 将 vmagent目标原子切换为三个新 metrics地址，只重建 vmagent，并确认所有正式 target
+   为 up；
+5. 将三个已退出旧容器的 restart policy改为 `no`，避免原宿主机或 Docker daemon重启时
+   自动重新加入 production group；
+6. 观察至少 90 分钟，再归档旧实例配置。验收前保留原容器和 state，不执行删除。
+
+回滚时反向操作：先在原主机启动一个旧 consumer，确认同一 group完成 rebalance后再停
+一个新 consumer，直至三个旧实例恢复。Kafka offset保存在 AutoMQ；不得复制或合并三个
+consumer的本地 state目录。
+
 ## 5. 当天门禁
 
 以下任何步骤失败都停止在当前安全状态，不压缩等待时间：

--- a/scripts/validate-automq.sh
+++ b/scripts/validate-automq.sh
@@ -30,9 +30,12 @@ validate_static() {
   local bootstrap="${root}/scripts/bootstrap-cluster.sh"
   local vvg="${root}/config/vector-vvg-consumer.yaml"
   local gateway="${root}/config/vector-gateway-consumer.yaml"
+  local remote_vvg_compose="${root}/docker-compose.vvg-consumers.yml"
+  local remote_vvg_env="${root}/vvg-consumers.env.example"
 
   for file in "${compose}" "${env}" "${server}" "${bootstrap}" \
-      "${vvg}" "${gateway}" "${root}/scripts/render-runtime.sh" \
+      "${vvg}" "${gateway}" "${remote_vvg_compose}" \
+      "${remote_vvg_env}" "${root}/scripts/render-runtime.sh" \
       "${root}/scripts/preflight-kafka.sh" \
       "${root}/scripts/preflight-obs.sh" \
       "${root}/scripts/backup-cce-vector.sh" \
@@ -66,6 +69,27 @@ validate_static() {
     "AutoMQ consumers pin Vector 0.58.0 by digest"
   forbid_regex "${env}" '(^|[=:])[^#[:space:]]*latest([[:space:]]|$)' \
     "AutoMQ environment has no latest image"
+  require_literal "${remote_vvg_env}" 'VECTOR_IMAGE=timberio/vector@sha256:' \
+    "Remote VVG consumers require an exact Vector digest"
+  forbid_regex "${remote_vvg_env}" '(^|[=:])[^#[:space:]]*latest([[:space:]]|$)' \
+    "Remote VVG consumer environment has no latest image"
+  forbid_regex "${remote_vvg_compose}" '192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.' \
+    "Remote VVG consumer template contains no real private address"
+  forbid_regex "${remote_vvg_compose}" '^version:' \
+    "Remote VVG consumer Compose omits the obsolete version field"
+  if [[ "$(grep -Fc 'container_name: automq-vector-vvg-production-' "${remote_vvg_compose}")" == 3 ]] &&
+     [[ "$(grep -Fc './state/vector-vvg-production-' "${remote_vvg_compose}")" == 3 ]] &&
+     [[ "$(grep -Ec '19(598|599|600):9598' "${remote_vvg_compose}")" == 3 ]]; then
+    pass "Remote VVG deployment has three explicit consumers with isolated state and metrics"
+  else
+    fail "Remote VVG deployment requires three explicit consumers with isolated state and metrics"
+  fi
+  require_literal "${remote_vvg_compose}" 'stop_grace_period: 2m' \
+    "Remote VVG consumers stop gracefully"
+  require_literal "${remote_vvg_compose}" 'mem_limit: 1536m' \
+    "Remote VVG consumers keep the production memory limit"
+  require_literal "${remote_vvg_compose}" 'memswap_limit: 1536m' \
+    "Remote VVG consumers cannot consume additional swap"
   require_literal "${compose}" 'pull_policy: never' \
     "AutoMQ stack cannot pull images during startup"
   require_literal "${compose}" 'cpus: 3.0' \
@@ -387,6 +411,9 @@ validate_runtime() {
   docker compose --env-file "${root}/env.example" \
     -f "${root}/docker-compose.yml" --profile shadow --profile production config --quiet
   pass "AutoMQ Compose expands with both rollout profiles"
+  docker compose --env-file "${root}/vvg-consumers.env.example" \
+    -f "${root}/docker-compose.vvg-consumers.yml" config --quiet
+  pass "Remote VVG consumer Compose expands"
   validate_vector "${root}/config/vector-vvg-consumer.yaml" 9598
   validate_vector "${root}/config/vector-gateway-consumer.yaml" 9599
   VECTOR_IMAGE=timberio/vector:0.58.0-alpine \


### PR DESCRIPTION
## Summary

- add a standalone three-instance VVG consumer Compose deployment for placing consumers with VictoriaLogs
- isolate per-instance Vector state and metrics endpoints while preserving the production Kafka group, limits, acknowledgements, and graceful shutdown
- document rolling cross-host cutover, restart-policy safety, monitoring handoff, and reverse rolling rollback
- extend static and runtime validation without storing deployment addresses or credentials

## Production validation

- target host Compose 1.29 configuration expansion passed
- Vector 0.58 configuration compiled in the exact target image
- three consumers rolled one at a time into the existing production group
- three source consumers exited with code 0 and automatic restart disabled; AutoMQ and Gateway remained running
- vmagent consumer targets are 4/4 up, including the unchanged Gateway consumer
- user-approved 15-minute observation completed: 15/15 samples kept three group members and three metrics targets, with zero Vector/Broker errors, restarts, or OOM
- lag ranged from 327 to 5492 and returned to 788 at final acceptance, with no sustained growth
- VictoriaLogs had 16/16 non-empty one-minute buckets in the final 15-minute query window
- final source and target evidence archives include SHA-256 manifests

## Checks

- `bash -n scripts/validate-automq.sh`
- `bash scripts/validate-automq.sh --static`
- `node scripts/validate-vvg-message-filter.mjs`
- `bash scripts/validate-configs.sh --static`
- target-host `docker-compose config --quiet`
- target-host exact-image `vector validate --no-environment`
- `git diff --check`

Local Docker CLI was unavailable; target-host Compose expansion and Vector runtime compilation covered the new deployment artifact, and GitHub Actions ran the repository validation on Linux.