### PR TITLE
feat: add production AutoMQ and VictoriaLogs monitoring

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.sh text eol=lf
 Dockerfile text eol=lf
+docker-compose/victorialogs/monitoring/grafana/victorialogs-v1.52.0.json binary

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Pull Request 和 `main` 分支会通过 GitHub Actions 重复执行完整校验�
 - [生产日志检索大屏配置与导入指南](docs/grafana-victorialogs-log-search-dashboard-guide.md)
 - [Grafana/VictoriaLogs 查询性能与升级运行手册](docs/grafana-victorialogs-query-performance-runbook.md)
 - [Vector/VictoriaLogs 延迟排查与升级运行手册](docs/vector-victorialogs-latency-runbook.md)
+- [VictoriaLogs 官方运行监控大屏](docker-compose/victorialogs/monitoring/README.md)
 - [故障排查指南](docs/troubleshooting.md)
 - [AI Agent 配置、升级与验收指南](docs/ai-agent-operations-guide.md)
 

--- a/docker-compose/automq/README.md
+++ b/docker-compose/automq/README.md
@@ -23,6 +23,7 @@ Vector 直写 VictoriaLogs/ClickHouse 配置，以减少组件与故障面；直
 - Kafka protocol `3.9.1`；
 - Vector `0.58.0-alpine`；
 - vmagent `v1.147.0`；
+- vmagent 同时抓取 AutoMQ、Vector、宿主机、VictoriaLogs 与自身指标；
 - AutoMQ `3 CPU / 6 GiB`，官方 Tiny 内存参数（Heap 1 GiB、Direct Memory 1.5 GiB）；
 - VVG Topic 12 partitions，Gateway Topic 6 partitions；
 - 单条 4 MiB、Zstd、72 小时 retention、replication factor 1；
@@ -83,6 +84,10 @@ docker compose --env-file .env --profile production up -d \
 
 不能让 shadow 和 production 消费者同时写同一个正式后端。生产 group 首次启动
 必须先于生产者主切，使用 `latest` 建立当前末尾 offset，避免把影子历史重新灌入。
+
+`.env` 中的 `VICTORIALOGS_METRICS_TARGET` 只填写 `host:port`，由
+`scripts/render-runtime.sh` 渲染为 `victorialogs` scrape job。更换该单文件 bind mount
+后必须只重建 `vmagent`，不能假定旧容器会自动读取新 inode。
 
 ### VVG consumer 跨主机放置
 

--- a/docker-compose/automq/config/prometheus.yml.template
+++ b/docker-compose/automq/config/prometheus.yml.template
@@ -33,3 +33,13 @@ scrape_configs:
       - targets: ["host.docker.internal:9100"]
         labels:
           automq_host: "true"
+
+  - job_name: victorialogs
+    static_configs:
+      - targets: ["__VICTORIALOGS_METRICS_TARGET__"]
+        labels:
+          deployment: "vvg-production"
+
+  - job_name: automq-vmagent
+    static_configs:
+      - targets: ["vmagent:8429"]

--- a/docker-compose/automq/env.example
+++ b/docker-compose/automq/env.example
@@ -16,6 +16,7 @@ VVG_TENANT_ID=99:99
 GATEWAY_CLICKHOUSE_TABLE=nginx_access_automq_shadow
 
 VICTORIALOGS_URL=http://victorialogs.example.internal:9428
+VICTORIALOGS_METRICS_TARGET=victorialogs.example.internal:9428
 CLICKHOUSE_URL=http://clickhouse.example.internal:8123
 CLICKHOUSE_DATABASE=nginxlogs
 VICTORIAMETRICS_REMOTE_WRITE_URL=http://victoriametrics.example.internal:8428/api/v1/write

--- a/docker-compose/automq/monitoring/README.md
+++ b/docker-compose/automq/monitoring/README.md
@@ -13,13 +13,29 @@ datasource. Do not place them in a generic infrastructure group, and do not put
 notification tokens or real contact details in Git.
 
 Import `nightingale/automq-cluster.json` into the Jinling Cloud SaaS business
-group. This is a native Nightingale dashboard. Do not use the Grafana
-compatibility importer for the final Nightingale copy because transformed table
-panels are downgraded to the unsupported `unknown` type.
+group. This is the production Nightingale dashboard and uses only native
+Nightingale v9 panel types. It keeps the official cluster queries, then adds
+Broker queues and latency, KRaft, JVM, object-storage/WAL/cache, Vector lag and
+buffer, host resources and vmagent health. Every panel has a human-readable
+name and description. Do not use the Grafana compatibility importer for the
+final Nightingale copy: the official overview intentionally leaves six stat
+titles empty and its transformed table panels lose important labels after
+conversion.
 
 The repository-level `docs/images/automq-dashboard-overview.png` is a sanitized
 layout preview with example values. Never replace it with a live production
 screenshot or runtime data.
 
 The bundled vmagent scrape configuration labels the local node-exporter target
-with `automq_host="true"`, so host resource alerts do not match other nodes.
+with `automq_host="true"`, so host resource alerts do not match other nodes. It
+also scrapes VictoriaLogs and vmagent itself. Set
+`VICTORIALOGS_METRICS_TARGET` to the reachable `host:port` of the production
+VictoriaLogs instance before rendering runtime configuration.
+
+The AutoMQ Cloud documentation describes separate Cluster, Broker, Topic and
+Group dashboards, but those templates are distributed through the AutoMQ Cloud
+workflow rather than the open-source `1.7.4` repository. Community Kafka
+dashboards generally expect JMX Exporter metric names and cannot be imported
+unchanged against AutoMQ's `kafka_*` and `kafka_stream_*` metrics. The native
+dashboard therefore stays pinned to AutoMQ's own metric contract instead of
+pretending a visually richer but incompatible community dashboard works.

--- a/docker-compose/automq/monitoring/nightingale/automq-cluster.json
+++ b/docker-compose/automq/monitoring/nightingale/automq-cluster.json
@@ -1,17 +1,35 @@
 {
-  "name": "AutoMQ Logs - Production",
-  "tags": "automq production logs",
-  "note": "AutoMQ log buffer health, throughput, lag and recovery signals.",
+  "name": "AutoMQ 生产集群监控（官方指标增强版）",
+  "tags": "automq production kafka victorialogs vector",
+  "note": "基于 AutoMQ 1.7.4 官方 Cluster Overview 与 Prometheus 指标语义，补齐夜莺原生标题、说明、Broker/请求/KRaft/JVM/S3/WAL/Vector 链路监控。单节点部署不是高可用架构。",
   "ident": "automq-production-cluster",
   "uuid": 1788455364871001,
   "configs": {
     "version": "3.4.0",
-    "links": [],
+    "links": [
+      {
+        "title": "AutoMQ 1.7.4 官方监控源",
+        "url": "https://github.com/AutoMQ/automq/blob/1.7.4/docker/telemetry/grafana/provisioning/dashboards/User/cluster.json",
+        "targetBlank": true
+      },
+      {
+        "title": "AutoMQ 指标说明",
+        "url": "https://docs.automq.com/automq/observability/metrics",
+        "targetBlank": true
+      }
+    ],
     "var": [
+      {
+        "type": "datasource",
+        "name": "datasource",
+        "label": "数据源",
+        "definition": "prometheus",
+        "hide": false
+      },
       {
         "type": "query",
         "name": "cluster_id",
-        "label": "Cluster",
+        "label": "AutoMQ 集群",
         "allOption": false,
         "multi": false,
         "reg": "",
@@ -21,34 +39,49 @@
           "cate": "prometheus",
           "value": "${datasource}"
         }
-      },
-      {
-        "type": "datasource",
-        "name": "datasource",
-        "label": "Data Source",
-        "definition": "prometheus",
-        "hide": false
       }
     ],
     "panels": [
       {
         "version": "3.4.0",
-        "id": "automq-controller",
-        "type": "stat",
-        "name": "Active Controller",
-        "links": [],
+        "id": "row-health",
+        "type": "row",
+        "name": "一、集群健康与容量",
+        "collapsed": true,
         "layout": {
-          "h": 6,
-          "w": 4,
+          "h": 1,
+          "w": 24,
           "x": 0,
           "y": 0,
+          "i": "row-health",
+          "isResizable": false
+        },
+        "targets": [],
+        "options": {},
+        "custom": {},
+        "overrides": [],
+        "transformationsNG": []
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-controller",
+        "type": "stat",
+        "name": "活动 Controller",
+        "description": "KRaft 当前活动 Controller 数量。单节点基线应为 1；为 0 时集群无法完成控制面操作。",
+        "links": [],
+        "layout": {
+          "h": 5,
+          "w": 3,
+          "x": 0,
+          "y": 1,
           "i": "automq-controller"
         },
         "targets": [
           {
             "refId": "A",
             "expr": "sum(kafka_controller_active_count{job=\"$cluster_id\"})",
-            "legend": "controller"
+            "legend": "Controller",
+            "instant": true
           }
         ],
         "options": {
@@ -58,17 +91,21 @@
             "style": "line",
             "steps": [
               {
-                "color": "#73BF69",
+                "color": "#F2495C",
                 "value": null,
                 "type": "base"
+              },
+              {
+                "color": "#73BF69",
+                "value": 1
               }
             ]
           },
           "standardOptions": {
-            "util": "none"
+            "unit": "none"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -78,10 +115,13 @@
         },
         "custom": {
           "version": "3.4.0",
-          "textMode": "value",
+          "textMode": "valueAndName",
           "calc": "lastNotNull",
-          "colorMode": "value"
+          "colorMode": "value",
+          "textSize": {}
         },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"
@@ -90,20 +130,22 @@
         "version": "3.4.0",
         "id": "automq-broker",
         "type": "stat",
-        "name": "Active Broker",
+        "name": "活动 Broker",
+        "description": "当前可提供 Kafka 读写服务的 Broker 数量。现网单节点基线应为 1。",
         "links": [],
         "layout": {
-          "h": 6,
-          "w": 4,
-          "x": 4,
-          "y": 0,
+          "h": 5,
+          "w": 3,
+          "x": 3,
+          "y": 1,
           "i": "automq-broker"
         },
         "targets": [
           {
             "refId": "A",
             "expr": "sum(kafka_broker_active_count{job=\"$cluster_id\"})",
-            "legend": "broker"
+            "legend": "Broker",
+            "instant": true
           }
         ],
         "options": {
@@ -113,17 +155,21 @@
             "style": "line",
             "steps": [
               {
-                "color": "#73BF69",
+                "color": "#F2495C",
                 "value": null,
                 "type": "base"
+              },
+              {
+                "color": "#73BF69",
+                "value": 1
               }
             ]
           },
           "standardOptions": {
-            "util": "none"
+            "unit": "none"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -133,10 +179,13 @@
         },
         "custom": {
           "version": "3.4.0",
-          "textMode": "value",
+          "textMode": "valueAndName",
           "calc": "lastNotNull",
-          "colorMode": "value"
+          "colorMode": "value",
+          "textSize": {}
         },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"
@@ -145,20 +194,22 @@
         "version": "3.4.0",
         "id": "automq-fenced",
         "type": "stat",
-        "name": "Fenced Broker",
+        "name": "被隔离 Broker",
+        "description": "被 Controller 隔离、不能承担读写的 Broker 数量。正常值为 0。",
         "links": [],
         "layout": {
-          "h": 6,
-          "w": 4,
-          "x": 8,
-          "y": 0,
+          "h": 5,
+          "w": 3,
+          "x": 6,
+          "y": 1,
           "i": "automq-fenced"
         },
         "targets": [
           {
             "refId": "A",
             "expr": "sum(kafka_broker_fenced_count{job=\"$cluster_id\"}) or vector(0)",
-            "legend": "fenced"
+            "legend": "Fenced",
+            "instant": true
           }
         ],
         "options": {
@@ -179,10 +230,10 @@
             ]
           },
           "standardOptions": {
-            "util": "none"
+            "unit": "none"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -192,10 +243,77 @@
         },
         "custom": {
           "version": "3.4.0",
-          "textMode": "value",
+          "textMode": "valueAndName",
           "calc": "lastNotNull",
-          "colorMode": "value"
+          "colorMode": "value",
+          "textSize": {}
         },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-offline",
+        "type": "stat",
+        "name": "离线分区",
+        "description": "没有可用 Leader 的分区数量。正常值为 0；大于 0 会直接影响生产或消费。",
+        "links": [],
+        "layout": {
+          "h": 5,
+          "w": 3,
+          "x": 9,
+          "y": 1,
+          "i": "automq-offline"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(kafka_partition_offline_count{job=\"$cluster_id\"}) or vector(0)",
+            "legend": "Offline",
+            "instant": true
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              },
+              {
+                "color": "#F2495C",
+                "value": 1
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "none"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "valueAndName",
+          "calc": "lastNotNull",
+          "colorMode": "value",
+          "textSize": {}
+        },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"
@@ -204,20 +322,22 @@
         "version": "3.4.0",
         "id": "automq-topics",
         "type": "stat",
-        "name": "Topics",
+        "name": "Topic 数",
+        "description": "AutoMQ 中当前 Topic 总数，包含系统内部 Topic。",
         "links": [],
         "layout": {
-          "h": 6,
-          "w": 4,
+          "h": 5,
+          "w": 3,
           "x": 12,
-          "y": 0,
+          "y": 1,
           "i": "automq-topics"
         },
         "targets": [
           {
             "refId": "A",
-            "expr": "sum(kafka_topic_count{job=\"$cluster_id\"})",
-            "legend": "topics"
+            "expr": "max(kafka_topic_count{job=\"$cluster_id\"})",
+            "legend": "Topics",
+            "instant": true
           }
         ],
         "options": {
@@ -234,10 +354,10 @@
             ]
           },
           "standardOptions": {
-            "util": "none"
+            "unit": "none"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -247,10 +367,13 @@
         },
         "custom": {
           "version": "3.4.0",
-          "textMode": "value",
+          "textMode": "valueAndName",
           "calc": "lastNotNull",
-          "colorMode": "value"
+          "colorMode": "value",
+          "textSize": {}
         },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"
@@ -259,20 +382,22 @@
         "version": "3.4.0",
         "id": "automq-partitions",
         "type": "stat",
-        "name": "Partitions",
+        "name": "分区总数",
+        "description": "所有 Topic 的分区总数。现网业务 Topic 之外还包含 Kafka/AutoMQ 系统分区。",
         "links": [],
         "layout": {
-          "h": 6,
-          "w": 4,
-          "x": 16,
-          "y": 0,
+          "h": 5,
+          "w": 3,
+          "x": 15,
+          "y": 1,
           "i": "automq-partitions"
         },
         "targets": [
           {
             "refId": "A",
-            "expr": "sum(kafka_partition_total_count{job=\"$cluster_id\"})",
-            "legend": "partitions"
+            "expr": "max(kafka_partition_total_count{job=\"$cluster_id\"})",
+            "legend": "Partitions",
+            "instant": true
           }
         ],
         "options": {
@@ -289,10 +414,10 @@
             ]
           },
           "standardOptions": {
-            "util": "none"
+            "unit": "none"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -302,10 +427,13 @@
         },
         "custom": {
           "version": "3.4.0",
-          "textMode": "value",
+          "textMode": "valueAndName",
           "calc": "lastNotNull",
-          "colorMode": "value"
+          "colorMode": "value",
+          "textSize": {}
         },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"
@@ -314,20 +442,22 @@
         "version": "3.4.0",
         "id": "automq-size",
         "type": "stat",
-        "name": "Stored Log Bytes",
+        "name": "逻辑日志量",
+        "description": "按 Topic/Partition 去重后的 Kafka 逻辑日志大小，不等于 OBS 实际计费容量。",
         "links": [],
         "layout": {
-          "h": 6,
-          "w": 4,
-          "x": 20,
-          "y": 0,
+          "h": 5,
+          "w": 3,
+          "x": 18,
+          "y": 1,
           "i": "automq-size"
         },
         "targets": [
           {
             "refId": "A",
             "expr": "sum(max by(topic,partition) (kafka_log_size{job=\"$cluster_id\"}))",
-            "legend": "bytes"
+            "legend": "Stored",
+            "instant": true
           }
         ],
         "options": {
@@ -344,10 +474,10 @@
             ]
           },
           "standardOptions": {
-            "util": "bytesIEC"
+            "unit": "bytesIEC"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -357,37 +487,131 @@
         },
         "custom": {
           "version": "3.4.0",
-          "textMode": "value",
+          "textMode": "valueAndName",
           "calc": "lastNotNull",
-          "colorMode": "value"
+          "colorMode": "value",
+          "textSize": {}
         },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"
       },
       {
         "version": "3.4.0",
-        "id": "automq-network",
-        "type": "timeseries",
-        "name": "Broker Bytes In / Out",
+        "id": "automq-errors",
+        "type": "stat",
+        "name": "错误请求/秒",
+        "description": "Kafka 非 NONE 错误响应速率。短时认证探测可能产生少量错误，持续增长必须按 error 标签定位。",
         "links": [],
         "layout": {
-          "h": 10,
-          "w": 12,
+          "h": 5,
+          "w": 3,
+          "x": 21,
+          "y": 1,
+          "i": "automq-errors"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(rate(kafka_request_error_count_total{job=\"$cluster_id\",error!=\"NONE\"}[$__rate_interval])) or vector(0)",
+            "legend": "Errors/s",
+            "instant": true
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              },
+              {
+                "color": "#FADE2A",
+                "value": 0.01
+              },
+              {
+                "color": "#F2495C",
+                "value": 1
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "reqps"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "valueAndName",
+          "calc": "lastNotNull",
+          "colorMode": "value",
+          "textSize": {}
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "row-traffic",
+        "type": "row",
+        "name": "二、流量、请求与 Broker 压力",
+        "collapsed": true,
+        "layout": {
+          "h": 1,
+          "w": 24,
           "x": 0,
           "y": 6,
+          "i": "row-traffic",
+          "isResizable": false
+        },
+        "targets": [],
+        "options": {},
+        "custom": {},
+        "overrides": [],
+        "transformationsNG": []
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-network",
+        "type": "timeseries",
+        "name": "Broker 网络吞吐",
+        "description": "Broker 接收与发送字节速率；入站主要是 producer，出站主要是 consumer。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 7,
           "i": "automq-network"
         },
         "targets": [
           {
             "refId": "A",
             "expr": "sum(rate(kafka_broker_network_io_bytes_total{job=\"$cluster_id\",direction=\"in\"}[$__rate_interval]))",
-            "legend": "in"
+            "legend": "写入",
+            "instant": false
           },
           {
             "refId": "B",
             "expr": "sum(rate(kafka_broker_network_io_bytes_total{job=\"$cluster_id\",direction=\"out\"}[$__rate_interval]))",
-            "legend": "out"
+            "legend": "读取",
+            "instant": false
           }
         ],
         "options": {
@@ -404,10 +628,10 @@
             ]
           },
           "standardOptions": {
-            "util": "bytesSIps"
+            "unit": "bytesSecIEC"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -419,136 +643,17 @@
           "version": "3.4.0",
           "drawStyle": "lines",
           "lineInterpolation": "linear",
-          "fillOpacity": 0.2,
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
           "stack": "off"
         },
-        "maxPerRow": 4,
-        "datasourceCate": "prometheus",
-        "datasourceValue": "${datasource}"
-      },
-      {
-        "version": "3.4.0",
-        "id": "automq-requests",
-        "type": "timeseries",
-        "name": "Produce / Fetch Requests",
-        "links": [],
-        "layout": {
-          "h": 10,
-          "w": 12,
-          "x": 12,
-          "y": 6,
-          "i": "automq-requests"
-        },
-        "targets": [
-          {
-            "refId": "A",
-            "expr": "sum(rate(kafka_request_count_total{job=\"$cluster_id\",type=\"Produce\"}[$__rate_interval]))",
-            "legend": "produce"
-          },
-          {
-            "refId": "B",
-            "expr": "sum(rate(kafka_request_count_total{job=\"$cluster_id\",type=\"Fetch\"}[$__rate_interval]))",
-            "legend": "fetch"
-          },
-          {
-            "refId": "C",
-            "expr": "sum(rate(kafka_request_error_count_total{job=\"$cluster_id\",error!=\"NONE\"}[$__rate_interval])) or vector(0)",
-            "legend": "errors"
-          }
-        ],
-        "options": {
-          "valueMappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "style": "line",
-            "steps": [
-              {
-                "color": "#73BF69",
-                "value": null,
-                "type": "base"
-              }
-            ]
-          },
-          "standardOptions": {
-            "util": "reqps"
-          },
-          "legend": {
-            "displayMode": "list",
-            "placement": "bottom"
-          },
-          "tooltip": {
-            "mode": "all",
-            "sort": "desc"
-          }
-        },
-        "custom": {
-          "version": "3.4.0",
-          "drawStyle": "lines",
-          "lineInterpolation": "linear",
-          "fillOpacity": 0.2,
-          "stack": "off"
-        },
-        "maxPerRow": 4,
-        "datasourceCate": "prometheus",
-        "datasourceValue": "${datasource}"
-      },
-      {
-        "version": "3.4.0",
-        "id": "automq-latency",
-        "type": "timeseries",
-        "name": "Kafka Request P99",
-        "links": [],
-        "layout": {
-          "h": 10,
-          "w": 12,
-          "x": 0,
-          "y": 16,
-          "i": "automq-latency"
-        },
-        "targets": [
-          {
-            "refId": "A",
-            "expr": "max(kafka_request_time_99p_milliseconds{job=\"$cluster_id\",type=\"Produce\"})",
-            "legend": "produce"
-          },
-          {
-            "refId": "B",
-            "expr": "max(kafka_request_time_99p_milliseconds{job=\"$cluster_id\",type=\"Fetch\"})",
-            "legend": "fetch"
-          }
-        ],
-        "options": {
-          "valueMappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "style": "line",
-            "steps": [
-              {
-                "color": "#73BF69",
-                "value": null,
-                "type": "base"
-              }
-            ]
-          },
-          "standardOptions": {
-            "util": "ms"
-          },
-          "legend": {
-            "displayMode": "list",
-            "placement": "bottom"
-          },
-          "tooltip": {
-            "mode": "all",
-            "sort": "desc"
-          }
-        },
-        "custom": {
-          "version": "3.4.0",
-          "drawStyle": "lines",
-          "lineInterpolation": "linear",
-          "fillOpacity": 0.2,
-          "stack": "off"
-        },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"
@@ -557,20 +662,22 @@
         "version": "3.4.0",
         "id": "automq-topic-rate",
         "type": "timeseries",
-        "name": "Topic Message Rate",
+        "name": "各 Topic 消息写入速率",
+        "description": "按 Topic 展示进入 Broker 的消息速率，用于识别 VVG 与 Gateway 流量变化。",
         "links": [],
         "layout": {
-          "h": 10,
+          "h": 9,
           "w": 12,
           "x": 12,
-          "y": 16,
+          "y": 7,
           "i": "automq-topic-rate"
         },
         "targets": [
           {
             "refId": "A",
             "expr": "sum by(topic) (rate(kafka_message_count_total{job=\"$cluster_id\",direction=\"in\"}[$__rate_interval]))",
-            "legend": "{{topic}} in"
+            "legend": "{{topic}}",
+            "instant": false
           }
         ],
         "options": {
@@ -587,10 +694,10 @@
             ]
           },
           "standardOptions": {
-            "util": "mps"
+            "unit": "mps"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -602,31 +709,47 @@
           "version": "3.4.0",
           "drawStyle": "lines",
           "lineInterpolation": "linear",
-          "fillOpacity": 0.2,
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
           "stack": "off"
         },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"
       },
       {
         "version": "3.4.0",
-        "id": "automq-consumer-lag",
+        "id": "automq-requests",
         "type": "timeseries",
-        "name": "Vector Consumer Lag",
+        "name": "Produce / Fetch 请求速率",
+        "description": "Broker 每秒处理的生产与拉取请求。请求数和消息数不同，一个请求可包含多个消息。",
         "links": [],
         "layout": {
-          "h": 10,
-          "w": 12,
+          "h": 9,
+          "w": 8,
           "x": 0,
-          "y": 26,
-          "i": "automq-consumer-lag"
+          "y": 16,
+          "i": "automq-requests"
         },
         "targets": [
           {
             "refId": "A",
-            "expr": "sum by(consumer_group,topic) (clamp_min(vector_kafka_consumer_lag{partition_id!=\"-1\"},0))",
-            "legend": "{{consumer_group}} / {{topic}}"
+            "expr": "sum(rate(kafka_request_count_total{job=\"$cluster_id\",type=\"Produce\"}[$__rate_interval]))",
+            "legend": "Produce",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "sum(rate(kafka_request_count_total{job=\"$cluster_id\",type=\"Fetch\"}[$__rate_interval]))",
+            "legend": "Fetch",
+            "instant": false
           }
         ],
         "options": {
@@ -643,10 +766,10 @@
             ]
           },
           "standardOptions": {
-            "util": "none"
+            "unit": "reqps"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -658,9 +781,451 @@
           "version": "3.4.0",
           "drawStyle": "lines",
           "lineInterpolation": "linear",
-          "fillOpacity": 0.2,
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
           "stack": "off"
         },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-latency",
+        "type": "timeseries",
+        "name": "Kafka 请求 P99 延迟",
+        "description": "Produce/Fetch 请求端到端处理时间的第 99 百分位；持续升高时结合队列、线程空闲率和 S3 延迟判断。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 8,
+          "y": 16,
+          "i": "automq-latency"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(kafka_request_time_99p_milliseconds{job=\"$cluster_id\",type=\"Produce\"})",
+            "legend": "Produce P99",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "max(kafka_request_time_99p_milliseconds{job=\"$cluster_id\",type=\"Fetch\"})",
+            "legend": "Fetch P99",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "ms"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-request-errors",
+        "type": "timeseries",
+        "name": "Kafka 错误响应明细",
+        "description": "按 Kafka error 标签拆分非成功响应，便于区分认证、Leader、超时和消息过大等错误。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 16,
+          "y": 16,
+          "i": "automq-request-errors"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum by(error,type) (rate(kafka_request_error_count_total{job=\"$cluster_id\",error!=\"NONE\"}[$__rate_interval]))",
+            "legend": "{{type}} / {{error}}",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "reqps"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-queues",
+        "type": "timeseries",
+        "name": "请求与响应队列",
+        "description": "Broker 网络线程与 I/O 线程之间的等待队列。持续堆积通常表示线程或下游存储处理不及。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 0,
+          "y": 25,
+          "i": "automq-queues"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max by(type) (kafka_request_queue_size{job=\"$cluster_id\"})",
+            "legend": "请求 {{type}}",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "max by(type) (kafka_response_queue_size{job=\"$cluster_id\"})",
+            "legend": "响应 {{type}}",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "none"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-purgatory",
+        "type": "timeseries",
+        "name": "延迟请求等待数",
+        "description": "等待副本确认或数据可用的 Produce/Fetch 请求数量。持续上升要检查 Broker、Leader 与对象存储。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 8,
+          "y": 25,
+          "i": "automq-purgatory"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum by(type) (kafka_purgatory_size{job=\"$cluster_id\"})",
+            "legend": "{{type}}",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "none"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-thread-idle",
+        "type": "timeseries",
+        "name": "网络 / I/O 线程空闲率",
+        "description": "线程空闲率越低表示 Broker 越忙。长期接近 0 时请求延迟和队列通常会同步升高。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 16,
+          "y": 25,
+          "i": "automq-thread-idle"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "min(kafka_network_threads_idle_rate{job=\"$cluster_id\"})",
+            "legend": "Network",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "min(kafka_io_threads_idle_rate_1m{job=\"$cluster_id\"})",
+            "legend": "I/O",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "percentUnit"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "row-delivery",
+        "type": "row",
+        "name": "三、生产者、消费者与积压",
+        "collapsed": true,
+        "layout": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 34,
+          "i": "row-delivery",
+          "isResizable": false
+        },
+        "targets": [],
+        "options": {},
+        "custom": {},
+        "overrides": [],
+        "transformationsNG": []
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-consumer-lag",
+        "type": "timeseries",
+        "name": "Vector Consumer Lag",
+        "description": "Kafka 最新 offset 与 Vector consumer 已提交 offset 的差值。正式 VVG/Gateway 组应在流量稳定后回落到低位。",
+        "links": [],
+        "layout": {
+          "h": 10,
+          "w": 12,
+          "x": 0,
+          "y": 35,
+          "i": "automq-consumer-lag"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum by(consumer_group,topic) (clamp_min(vector_kafka_consumer_lag{partition_id!=\"-1\"},0))",
+            "legend": "{{consumer_group}} / {{topic}}",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "none"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"
@@ -669,20 +1234,22 @@
         "version": "3.4.0",
         "id": "automq-producer-buffer",
         "type": "timeseries",
-        "name": "Vector Producer Disk Buffer",
+        "name": "Vector Producer 磁盘缓冲",
+        "description": "CCE producer 尚未可靠写入 AutoMQ 的本地磁盘队列。Broker 故障时会增长，恢复后必须持续下降。",
         "links": [],
         "layout": {
           "h": 10,
           "w": 12,
           "x": 12,
-          "y": 26,
+          "y": 35,
           "i": "automq-producer-buffer"
         },
         "targets": [
           {
             "refId": "A",
             "expr": "sum by(component_id,host) (vector_buffer_size_bytes{component_type=\"kafka\",component_id=~\"automq(_lane_[ab])?\"})",
-            "legend": "{{host}} / {{component_id}}"
+            "legend": "{{host}} / {{component_id}}",
+            "instant": false
           }
         ],
         "options": {
@@ -699,10 +1266,10 @@
             ]
           },
           "standardOptions": {
-            "util": "bytesIEC"
+            "unit": "bytesIEC"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -714,9 +1281,17 @@
           "version": "3.4.0",
           "drawStyle": "lines",
           "lineInterpolation": "linear",
-          "fillOpacity": 0.2,
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
           "stack": "off"
         },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"
@@ -725,35 +1300,52 @@
         "version": "3.4.0",
         "id": "automq-groups",
         "type": "barGauge",
-        "name": "Consumer Group State",
+        "name": "Consumer Group 状态",
+        "description": "stable 为正常工作组；preparing/completing_rebalance 持续非零表示频繁再均衡；empty/dead 多为历史组。",
         "links": [],
         "layout": {
           "h": 9,
-          "w": 12,
+          "w": 8,
           "x": 0,
-          "y": 36,
+          "y": 45,
           "i": "automq-groups"
         },
         "targets": [
           {
             "refId": "A",
             "expr": "sum(kafka_group_count{job=\"$cluster_id\"})",
-            "legend": "total"
+            "legend": "总数",
+            "instant": true
           },
           {
             "refId": "B",
             "expr": "sum(kafka_group_stable_count{job=\"$cluster_id\"})",
-            "legend": "stable"
+            "legend": "稳定",
+            "instant": true
           },
           {
             "refId": "C",
-            "expr": "sum(kafka_group_empty_count{job=\"$cluster_id\"})",
-            "legend": "empty"
+            "expr": "sum(kafka_group_preparing_rebalance_count{job=\"$cluster_id\"})",
+            "legend": "准备再均衡",
+            "instant": true
           },
           {
             "refId": "D",
+            "expr": "sum(kafka_group_completing_rebalance_count{job=\"$cluster_id\"})",
+            "legend": "完成再均衡",
+            "instant": true
+          },
+          {
+            "refId": "E",
+            "expr": "sum(kafka_group_empty_count{job=\"$cluster_id\"})",
+            "legend": "空组",
+            "instant": true
+          },
+          {
+            "refId": "F",
             "expr": "sum(kafka_group_dead_count{job=\"$cluster_id\"})",
-            "legend": "dead"
+            "legend": "已删除",
+            "instant": true
           }
         ],
         "options": {
@@ -770,10 +1362,10 @@
             ]
           },
           "standardOptions": {
-            "util": "none"
+            "unit": "none"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -783,30 +1375,43 @@
         },
         "custom": {
           "version": "3.4.0",
-          "calc": "lastNotNull"
+          "calc": "lastNotNull",
+          "displayMode": "basic",
+          "orientation": "horizontal",
+          "textSize": {}
         },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"
       },
       {
         "version": "3.4.0",
-        "id": "automq-s3",
+        "id": "automq-vector-throughput",
         "type": "timeseries",
-        "name": "Object Storage Operations",
+        "name": "Vector Kafka 收发事件速率",
+        "description": "各 producer/consumer Kafka 组件接收与发送事件速率，用来定位积压发生在入 Kafka 还是出 Kafka。",
         "links": [],
         "layout": {
           "h": 9,
-          "w": 12,
-          "x": 12,
-          "y": 36,
-          "i": "automq-s3"
+          "w": 8,
+          "x": 8,
+          "y": 45,
+          "i": "automq-vector-throughput"
         },
         "targets": [
           {
             "refId": "A",
-            "expr": "sum by(operation_name,status) (rate(kafka_stream_operation_latency_count{operation_type=\"S3Request\"}[$__rate_interval]))",
-            "legend": "{{operation_name}} / {{status}}"
+            "expr": "sum by(host,component_id) (rate(vector_component_received_events_total{component_type=\"kafka\"}[$__rate_interval]))",
+            "legend": "收到 {{host}} / {{component_id}}",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "sum by(host,component_id) (rate(vector_component_sent_events_total{component_type=\"kafka\"}[$__rate_interval]))",
+            "legend": "发出 {{host}} / {{component_id}}",
+            "instant": false
           }
         ],
         "options": {
@@ -823,10 +1428,10 @@
             ]
           },
           "standardOptions": {
-            "util": "reqps"
+            "unit": "mps"
           },
           "legend": {
-            "displayMode": "list",
+            "displayMode": "table",
             "placement": "bottom"
           },
           "tooltip": {
@@ -838,9 +1443,1259 @@
           "version": "3.4.0",
           "drawStyle": "lines",
           "lineInterpolation": "linear",
-          "fillOpacity": 0.2,
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
           "stack": "off"
         },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-vector-errors",
+        "type": "timeseries",
+        "name": "Vector 交付错误与丢弃",
+        "description": "Vector 组件错误和主动丢弃事件速率。生产链路持续非零必须结合 component_id 与 error_type 排查。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 16,
+          "y": 45,
+          "i": "automq-vector-errors"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum by(host,component_id,error_type) (rate(vector_component_errors_total[$__rate_interval]))",
+            "legend": "错误 {{host}} / {{component_id}} / {{error_type}}",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "sum by(host,component_id) (rate(vector_component_discarded_events_total[$__rate_interval]))",
+            "legend": "丢弃 {{host}} / {{component_id}}",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "mps"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "row-storage",
+        "type": "row",
+        "name": "四、S3 / OBS、WAL 与缓存",
+        "collapsed": true,
+        "layout": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 54,
+          "i": "row-storage",
+          "isResizable": false
+        },
+        "targets": [],
+        "options": {},
+        "custom": {},
+        "overrides": [],
+        "transformationsNG": []
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-s3-ops",
+        "type": "timeseries",
+        "name": "对象存储请求速率",
+        "description": "AutoMQ 到对象存储的 S3Request 操作速率，按操作名和状态拆分。非成功状态持续出现需要检查 OBS 网络、权限与限流。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 55,
+          "i": "automq-s3-ops"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum by(operation_name,status) (rate(kafka_stream_operation_latency_count{job=\"$cluster_id\",operation_type=\"S3Request\"}[$__rate_interval]))",
+            "legend": "{{operation_name}} / {{status}}",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "reqps"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-s3-latency",
+        "type": "timeseries",
+        "name": "对象存储操作 P99 延迟",
+        "description": "S3Request 操作第 99 百分位延迟。延迟升高会传导到 WAL 上传、冷读和 Kafka 请求尾延迟。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 55,
+          "i": "automq-s3-latency"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max by(operation_name,status) (kafka_stream_operation_latency_99p_nanoseconds{job=\"$cluster_id\",operation_type=\"S3Request\"}) / 1000000",
+            "legend": "{{operation_name}} / {{status}}",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "ms"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-s3-throughput",
+        "type": "timeseries",
+        "name": "对象存储上传 / 下载吞吐",
+        "description": "AutoMQ 向 OBS 上传和从 OBS 冷读的字节速率。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 0,
+          "y": 64,
+          "i": "automq-s3-throughput"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(rate(kafka_stream_upload_size_bytes_total{job=\"$cluster_id\"}[$__rate_interval]))",
+            "legend": "上传",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "sum(rate(kafka_stream_download_size_bytes_total{job=\"$cluster_id\"}[$__rate_interval]))",
+            "legend": "下载",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "bytesSecIEC"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-wal",
+        "type": "timeseries",
+        "name": "WAL 待上传字节",
+        "description": "本地 WAL 中等待上传到对象存储的数据。短暂波动正常，持续上升表示上传能力或对象存储异常。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 8,
+          "y": 64,
+          "i": "automq-wal"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(kafka_stream_wal_pending_upload_bytes{job=\"$cluster_id\"})",
+            "legend": "待上传",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "bytesIEC"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-cache",
+        "type": "timeseries",
+        "name": "AutoMQ 内存与缓存",
+        "description": "流缓冲、WAL cache 与 block cache 的实际占用，用于核对 6 GiB cgroup 内的 Tiny 内存基线。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 16,
+          "y": 64,
+          "i": "automq-cache"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(kafka_stream_buffer_allocated_memory_size_bytes{job=\"$cluster_id\"})",
+            "legend": "流缓冲",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "sum(kafka_stream_delta_wal_cache_size_bytes{job=\"$cluster_id\"})",
+            "legend": "WAL cache",
+            "instant": false
+          },
+          {
+            "refId": "C",
+            "expr": "sum(kafka_stream_block_cache_size_bytes{job=\"$cluster_id\"})",
+            "legend": "Block cache",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "bytesIEC"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-s3-objects",
+        "type": "timeseries",
+        "name": "S3 对象数量",
+        "description": "按对象状态统计 AutoMQ 管理的 S3 对象数量，用于观察对象增长和 compaction 是否异常。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 0,
+          "y": 73,
+          "i": "automq-s3-objects"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum by(state) (kafka_stream_s3_object_count{job=\"$cluster_id\"})",
+            "legend": "{{state}}",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "none"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-s3-object-size",
+        "type": "timeseries",
+        "name": "S3 对象容量",
+        "description": "按对象状态统计 AutoMQ 管理的 S3 对象总大小；这是对象层视角，与 Kafka 逻辑日志量口径不同。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 8,
+          "y": 73,
+          "i": "automq-s3-object-size"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum by(state) (kafka_stream_s3_object_size_bytes{job=\"$cluster_id\"})",
+            "legend": "{{state}}",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "bytesIEC"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-backpressure",
+        "type": "timeseries",
+        "name": "AutoMQ 背压与慢 Broker",
+        "description": "背压状态或 slow broker 数量非零表示写入/读取路径正在被限流或节点响应异常。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 16,
+          "y": 73,
+          "i": "automq-backpressure"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(kafka_stream_back_pressure_state{job=\"$cluster_id\"})",
+            "legend": "背压状态",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "max(kafka_stream_slow_broker_count{job=\"$cluster_id\"})",
+            "legend": "慢 Broker",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "none"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "row-runtime",
+        "type": "row",
+        "name": "五、KRaft、JVM、宿主机与采集器",
+        "collapsed": true,
+        "layout": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 82,
+          "i": "row-runtime",
+          "isResizable": false
+        },
+        "targets": [],
+        "options": {},
+        "custom": {},
+        "overrides": [],
+        "transformationsNG": []
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-kraft",
+        "type": "timeseries",
+        "name": "KRaft Leader / Epoch / High Watermark",
+        "description": "KRaft 控制面 Leader、epoch 和高水位。Leader 为 -1 或高水位长时间不推进表示元数据仲裁异常。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 0,
+          "y": 83,
+          "i": "automq-kraft"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(kafka_server_kraft_current_leader{job=\"$cluster_id\"})",
+            "legend": "Leader",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "max(kafka_server_kraft_current_epoch{job=\"$cluster_id\"})",
+            "legend": "Epoch",
+            "instant": false
+          },
+          {
+            "refId": "C",
+            "expr": "max(kafka_server_kraft_high_watermark{job=\"$cluster_id\"})",
+            "legend": "High watermark",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "none"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-kraft-latency",
+        "type": "timeseries",
+        "name": "KRaft 提交延迟",
+        "description": "控制面 Raft 日志提交平均值与最大值。单节点仍需关注磁盘或线程阻塞造成的尖峰。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 8,
+          "y": 83,
+          "i": "automq-kraft-latency"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(kafka_server_kraft_commit_latency_avg_milliseconds{job=\"$cluster_id\"})",
+            "legend": "平均",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "max(kafka_server_kraft_commit_latency_max_milliseconds{job=\"$cluster_id\"})",
+            "legend": "最大",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "ms"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-event-queue",
+        "type": "timeseries",
+        "name": "Controller 事件队列 P99",
+        "description": "控制器事件排队和处理第 99 百分位耗时；排队高而处理低通常是线程繁忙，二者都高需查资源与存储。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 16,
+          "y": 83,
+          "i": "automq-event-queue"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(kafka_event_queue_time_99p_milliseconds{job=\"$cluster_id\"})",
+            "legend": "排队",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "max(kafka_event_queue_processing_time_99p_milliseconds{job=\"$cluster_id\"})",
+            "legend": "处理",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "ms"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-jvm-memory",
+        "type": "timeseries",
+        "name": "JVM 内存使用",
+        "description": "JVM 各内存池使用量。显式 Heap/Direct 之外还需为 native、线程栈、ZGC 和网络缓冲保留空间。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 0,
+          "y": 92,
+          "i": "automq-jvm-memory"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum by(area,type) (jvm_memory_used_bytes{job=\"$cluster_id\"})",
+            "legend": "{{area}} / {{type}}",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "bytesIEC"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-jvm-cpu-gc",
+        "type": "timeseries",
+        "name": "JVM CPU 与 GC",
+        "description": "进程 CPU 利用率和平均 GC 停顿。GC 持续升高时结合内存占用与宿主机压力判断。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 8,
+          "y": 92,
+          "i": "automq-jvm-cpu-gc"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(jvm_cpu_recent_utilization_ratio{job=\"$cluster_id\"})",
+            "legend": "CPU",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "sum(rate(jvm_gc_duration_seconds_sum{job=\"$cluster_id\"}[$__rate_interval])) / clamp_min(sum(rate(jvm_gc_duration_seconds_count{job=\"$cluster_id\"}[$__rate_interval])),1)",
+            "legend": "平均 GC 秒",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "none"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-host",
+        "type": "timeseries",
+        "name": "AutoMQ 宿主机 CPU / 内存使用率",
+        "description": "只匹配 automq_host=true 的 node-exporter，避免把其他节点资源混入。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 8,
+          "x": 16,
+          "y": 92,
+          "i": "automq-host"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "1 - avg(rate(node_cpu_seconds_total{automq_host=\"true\",mode=\"idle\"}[$__rate_interval]))",
+            "legend": "CPU",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "1 - (node_memory_MemAvailable_bytes{automq_host=\"true\"} / node_memory_MemTotal_bytes{automq_host=\"true\"})",
+            "legend": "内存",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              },
+              {
+                "color": "#FADE2A",
+                "value": 0.8
+              },
+              {
+                "color": "#F2495C",
+                "value": 0.9
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "percentUnit"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-vmagent-health",
+        "type": "timeseries",
+        "name": "vmagent 抓取与 Remote Write 健康",
+        "description": "抓取失败或 Remote Write 待发送数据持续增长时，夜莺看到的曲线可能滞后，不能误判为被监控服务无流量。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 101,
+          "i": "automq-vmagent-health"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum by(job) (rate(vm_promscrape_scrapes_failed_total{job=\"automq-vmagent\"}[$__rate_interval]))",
+            "legend": "抓取失败 {{job}}",
+            "instant": false
+          },
+          {
+            "refId": "B",
+            "expr": "sum(vmagent_remotewrite_pending_data_bytes{job=\"automq-vmagent\"})",
+            "legend": "Remote Write 待发送字节",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "none"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${datasource}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "automq-jvm-threads",
+        "type": "timeseries",
+        "name": "JVM 线程数",
+        "description": "AutoMQ JVM 当前平台线程数。持续单向增长可能表示线程泄漏或连接/任务堆积。",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 101,
+          "i": "automq-jvm-threads"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(jvm_thread_count{job=\"$cluster_id\"})",
+            "legend": "Threads",
+            "instant": false
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null,
+                "type": "base"
+              }
+            ]
+          },
+          "standardOptions": {
+            "unit": "none"
+          },
+          "legend": {
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "lineWidth": 2,
+          "fillOpacity": 0.18,
+          "gradientMode": "none",
+          "showPoints": "never",
+          "scaleDistribution": {
+            "type": "linear"
+          },
+          "stack": "off"
+        },
+        "overrides": [],
+        "transformationsNG": [],
         "maxPerRow": 4,
         "datasourceCate": "prometheus",
         "datasourceValue": "${datasource}"

--- a/docker-compose/automq/scripts/render-runtime.sh
+++ b/docker-compose/automq/scripts/render-runtime.sh
@@ -61,6 +61,7 @@ region="$(read_env AUTOMQ_OBS_REGION)"
 endpoint="$(read_env AUTOMQ_OBS_ENDPOINT)"
 cce_node_1="$(read_env CCE_NODE_1)"
 cce_node_2="$(read_env CCE_NODE_2)"
+victorialogs_metrics_target="$(read_env VICTORIALOGS_METRICS_TARGET)"
 
 require_safe_value AUTOMQ_HOST_IP "${host_ip}" '^[0-9A-Fa-f:.]+$'
 require_safe_value AUTOMQ_EXTERNAL_PORT "${external_port}" '^[0-9]{2,5}$'
@@ -69,6 +70,8 @@ require_safe_value AUTOMQ_OBS_REGION "${region}" '^[a-z0-9-]+$'
 require_safe_value AUTOMQ_OBS_ENDPOINT "${endpoint}" '^https://[A-Za-z0-9.-]+(:[0-9]+)?$'
 require_safe_value CCE_NODE_1 "${cce_node_1}" '^[0-9A-Fa-f:.]+$'
 require_safe_value CCE_NODE_2 "${cce_node_2}" '^[0-9A-Fa-f:.]+$'
+require_safe_value VICTORIALOGS_METRICS_TARGET "${victorialogs_metrics_target}" \
+  '^[A-Za-z0-9.-]+:[0-9]{2,5}$'
 
 sed \
   -e "s/__AUTOMQ_HOST_IP__/${host_ip}/g" \
@@ -96,6 +99,7 @@ done
 sed \
   -e "s/__CCE_NODE_1__/${cce_node_1}/g" \
   -e "s/__CCE_NODE_2__/${cce_node_2}/g" \
+  -e "s/__VICTORIALOGS_METRICS_TARGET__/${victorialogs_metrics_target}/g" \
   config/prometheus.yml.template > runtime/prometheus.yml
 chmod 0644 runtime/prometheus.yml
 

--- a/docker-compose/victorialogs/README.md
+++ b/docker-compose/victorialogs/README.md
@@ -91,6 +91,20 @@ curl -fsS http://127.0.0.1:9428/metrics | grep -E \
 
 每次只增加一个小档位并复测 P95/P99。若触顶计数为 0，提高并发不会解决浏览器取消、错误查询语法或网络问题。
 
+## 运行监控
+
+VictoriaLogs 在 `/metrics` 暴露官方 Prometheus 指标。生产 vmagent 应使用独立
+`victorialogs` job抓取该端点，再 remote write到夜莺使用的 VictoriaMetrics数据源。
+
+仓库提供两份固定版本的大屏：
+
+- `monitoring/grafana/victorialogs-v1.52.0.json`：VictoriaLogs `v1.52.0` 官方原始文件，
+  保留官方 SHA-256；
+- `monitoring/nightingale/victorialogs-v1.52.0.json`：夜莺 v9.1.1 原生版本，保留全部
+  73 个面板，并把唯一不支持的 Grafana table转换为 `barGauge`。
+
+来源、校验和、导入方式和升级边界见 [监控资产说明](monitoring/README.md)。
+
 ## API 使用
 
 ### 数据写入

--- a/docker-compose/victorialogs/monitoring/README.md
+++ b/docker-compose/victorialogs/monitoring/README.md
@@ -1,0 +1,42 @@
+# VictoriaLogs monitoring assets
+
+`grafana/victorialogs-v1.52.0.json` is the official VictoriaLogs single-node
+dashboard published with VictoriaLogs `v1.52.0`. It is vendored byte-for-byte
+from:
+
+```text
+https://github.com/VictoriaMetrics/VictoriaLogs/blob/v1.52.0/dashboards/victorialogs.json
+```
+
+Expected SHA-256:
+
+```text
+07a17ece43627672bdc8335a6e51a881c11ae58f184f51623094e204d84be569
+```
+
+The dashboard contains 73 panels covering availability, ingestion, query
+latency and concurrency, dropped logs, storage, merges, CPU, memory, disk I/O,
+file descriptors and process restarts. Its default range is three hours. The
+dashboard expects a Prometheus-compatible datasource and the standard `job`,
+`instance` and `version` labels emitted by vmagent.
+
+`nightingale/victorialogs-v1.52.0.json` is the Nightingale v9.1.1 native import
+of the same pinned dashboard. It keeps all 73 panels, removes the duplicate
+datasource variable created by the compatibility importer, and converts the
+single unsupported Grafana table (`Non-default flags`) to a native bar gauge.
+No metric query is changed.
+
+Import the native JSON into the Jinling Cloud SaaS business group and select
+the existing VictoriaMetrics datasource. The production vmagent must scrape
+the VictoriaLogs `/metrics` endpoint under the `victorialogs` job before the
+dashboard is imported.
+
+Refresh the pinned copy only when VictoriaLogs itself is upgraded:
+
+```bash
+node scripts/vendor-victorialogs-dashboard.mjs
+node scripts/vendor-victorialogs-dashboard.mjs --check
+```
+
+Do not replace the pinned URL with a branch URL or a Grafana.com download URL.
+The Git tag and SHA-256 are the provenance and rollback boundary.

--- a/docker-compose/victorialogs/monitoring/grafana/victorialogs-v1.52.0.json
+++ b/docker-compose/victorialogs/monitoring/grafana/victorialogs-v1.52.0.json
@@ -1,0 +1,7866 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.3.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$DS_PROMETHEUS"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "blue",
+        "name": "version change",
+        "target": {
+          "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset $__interval) by(short_version))",
+          "interval": "",
+          "refId": "Anno"
+        },
+        "textFormat": "{{short_version}}",
+        "titleFormat": "Version change"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$DS_PROMETHEUS"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "orange",
+        "name": "restarts",
+        "target": {
+          "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(instance)",
+          "interval": "",
+          "refId": "Anno"
+        },
+        "textFormat": "{{instance}} restarted"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$DS_PROMETHEUS"
+        },
+        "enable": false,
+        "filter": {
+          "exclude": false,
+          "ids": [
+            75
+          ]
+        },
+        "hide": false,
+        "iconColor": "#57f26d1c",
+        "name": "gc",
+        "target": {
+          "expr": "go_memstats_last_gc_time_seconds{job=~\"$job\", instance=~\"$instance\"} * 1000",
+          "interval": "",
+          "refId": "Anno"
+        },
+        "textFormat": "GC event",
+        "useValueForTime": true
+      }
+    ]
+  },
+  "description": "Overview for single-node VictoriaLogs v1.29.0 or higher",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [
+    {
+      "icon": "doc",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Docs",
+      "type": "link",
+      "url": "https://docs.victoriametrics.com/victorialogs/"
+    },
+    {
+      "icon": "info",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Community support",
+      "type": "link",
+      "url": "https://victoriametrics.com/support/community-support/"
+    },
+    {
+      "asDropdown": false,
+      "icon": "bolt",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Enterprise support",
+      "tooltip": "",
+      "type": "link",
+      "url": "https://victoriametrics.com/support/enterprise-support/"
+    },
+    {
+      "icon": "info",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Releases",
+      "type": "link",
+      "url": "https://github.com/VictoriaMetrics/VictoriaLogs/releases"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Stats",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Total amount of log entries in the storage.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 0,
+        "y": 1
+      },
+      "id": 133,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(vl_storage_rows{job=~\"$job\", instance=~\"$instance\"})",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "Total log entries",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "The total number of log entries ingested over the past 24 hours.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 5,
+        "y": 1
+      },
+      "id": 134,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[24h]))",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "Ingested logs 24h",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Average ingestion rate of log entries.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 10,
+        "y": 1
+      },
+      "id": 135,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "Insert req/s",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Total amount of used disk space.\nAccounts for all compressed log entries and index size.\n\nSee how to [control disk usage](https://docs.victoriametrics.com/victorialogs/#retention-by-disk-space-usage).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 1
+      },
+      "id": 136,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(vl_data_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "Disk space usage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Integer number of CPU cores available to the application. This value is automatically rounded down from fractional CPU quotas. For optimal performance, fractional CPU units should be avoided. See the [best practices](https://docs.victoriametrics.com/victoriametrics/bestpractices/#kubernetes) documentation for more details.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 1
+      },
+      "id": 137,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(vm_available_cpu_cores{job=~\"$job\", instance=~\"$instance\"})",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "Available CPU",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Total log data (uncompressed) currently stored and still present in the system. This excludes data removed by retention or detached partitions.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 0,
+        "y": 5
+      },
+      "id": 144,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(vl_uncompressed_data_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "Total ingested size (uncompressed)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "The cumulative number of log entries ingested over the last 24h. \n\nThe size is calculated before compression.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 5,
+        "y": 5
+      },
+      "id": 139,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[24h]))",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "Ingested bytes 24h",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Rate of HTTP read requests.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 10,
+        "y": 5
+      },
+      "id": 140,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\", path=~\"/select/.*\"}[$__rate_interval]))",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "Read req/s",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "The ratio between original data size and compressed data stored on disk. This metric excludes indexdb size. \n\nThe ratio can go up or down as the system performs automatic maintenance and applies retention policies. For examples:\n- Background merges: [Merges](https://docs.victoriametrics.com/victorialogs/#forced-merge) improve compression by combining data into larger, more efficiently compressed blocks\n- Retention policies: When old data is deleted due to retention settings, the ratio changes as different time periods have varying compression characteristics\n\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 5
+      },
+      "id": 141,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": " sum(vl_uncompressed_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) / sum(vl_compressed_data_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Compression ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Total system memory available to the application. This represents the system or container's memory capacity or limit, not the currently free memory.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 5
+      },
+      "id": 142,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(vm_available_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "Available memory",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 18,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Ingestion rate in number of log entries and bytes per second.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*(bytes)/"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{type}} (bytes)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Logs ingestion rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{path}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 69,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path, reason)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{path}} - {{reason}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(vl_http_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{path}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Requests error rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Tail latency of VictoriaLogs HTTP endpoints, split by request `path` (seconds).\n\nThis shows the p99 response time, i.e. the slowest 1% of requests. It is the first place to look when users report 'slow queries' or 'slow ingestion'.\n\nBecause the chart takes the maximum across the selected instances, a single unhealthy node will stand out. If you see spikes, correlate with error rate and resource panels (CPU, memory, I/O pressure) to decide whether it is client load, a slow node, or storage pressure.\n\n`/internal/*` endpoints are excluded.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 66,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (path)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{path}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request duration p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Total amount of used disk space.\nAccounts for all compressed log entries and index size.\n\nSee how to [control disk usage](https://docs.victoriametrics.com/victorialogs/#retention-by-disk-space-usage).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(vl_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Disk space usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Rate of VictoriaLogs' own application log messages (debug, warnings, errors) - NOT the logs that VictoriaLogs is collecting from external sources.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Source Code",
+              "url": "https://l2s.victoriametrics.com/?app_version=${__field.labels.app_version}&location=${__field.labels.location}"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*warn:.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*error:.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 67,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[$__rate_interval])) by (instance, level, app_version, location)",
+          "interval": "5m",
+          "legendFormat": "{{instance}} - {{level}}: {{location}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "VictoriaLogs internal logging",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 28,
+      "panels": [],
+      "title": "Resource usage",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "How much memory (RAM) the VictoriaLogs process is actually using, compared to its allowed container or system limit. See 'Memory Usage' panel for a detailed breakdown.\n\n- Good: Below 70% most of the time, maybe spiking a bit under load.\n- Bad: Above 90% for more than 5 minutes = risk of out-of-memory (`OOM`) kill.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(\n    max_over_time(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n    /\n    process_memory_limit_bytes{job=~\"$job\", instance=~\"$instance\"}\n) by (instance)",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total memory % usage ($instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(\n    max_over_time(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n    /\n    process_memory_limit_bytes{job=~\"$job\", instance=~\"$instance\"}\n) by (instance)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Anonymous memory % usage ($instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Rate of allocations in memory. Sudden increase in allocations would mean increased pressure on Go Garbage Collector and can saturate CPU resources of the application.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "id": 145,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[$__rate_interval])) by (job)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory allocations rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Lower is better, e.g. 20% means the process was delayed by memory pressure 20% of the time. See [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\n- waiting: Time fraction where at least one thread was blocked on memory.\n- stalled: Time fraction where every thread was blocked on memory (severe pressure).\n\nIf queries slow down and both series spike, the host is likely limited by RAM or I/O throughput.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 0.2
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "id": 73,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(process_pressure_memory_waiting_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} - waiting",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(process_pressure_memory_stalled_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} - stalled",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Memory pressure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "CPU utilization per instance as a fraction of available cores. Sustained values above 80% indicate CPU saturation; correlate with CPU PSI and query latency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "id": 118,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(\n    rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n    /\n    process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}\n) by(instance)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU % usage ($instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Helps troubleshoot high CPU usage or throttling:\n\n- waiting: The percentage of time at least one task in the VictoriaLogs process was ready to run (runnable) but couldn't get scheduled on the CPU.\n- stalled: The percentage of time all tasks in the process (except idle ones) were unable to get CPU time — a full CPU stall.\n\nIf there's a CPU burst, it's normal to see waiting or stalled > 1%. It only becomes a concern if it consistently climbs above 5–10% and aligns with latency spikes or GC slowdowns.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "id": 72,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(process_pressure_cpu_waiting_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} - waiting",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(process_pressure_cpu_stalled_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} - stalled",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "CPU pressure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Measure the actual bytes read from and written to disk by the process:\n\n- read: physical bytes the kernel actually pulled from the storage device on behalf of the process (after checking page-cache).\n- write: physical bytes the kernel ultimately wrote to the storage device for the process (after combining, caching, or delaying writes).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "read"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 60
+      },
+      "id": 52,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "read",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "write",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Disk writes/reads ($instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Number of read/write calls application makes:\n\n- read call: Number of read*()-family system calls your process has issued since start. Each call can move 1 byte or megabytes, cached or uncached.\n- write call: Number of write*()-family system calls (including write, pwrite, writev, etc.) made by the process.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "read calls"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 60
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(process_io_read_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "read calls",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(process_io_write_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "write calls",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Storage read/write syscalls ($instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Percentage of open file descriptors (files, sockets, pipes, etc.,) compared to the limit set in the OS. Reaching the limit of open files can cause various issues and must be prevented.\n\nSee [how to change limits](https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "max"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C4162A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 68
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max_over_time(process_open_fds{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n/\nprocess_max_fds{job=~\"$job\", instance=~\"$instance\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Open FDs % usage ($instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "IO pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html). The lower the better.\n\n- waiting: at least one runnable thread blocked on block-`I/O` (disk, NVMe, network-storage) while others could still make progress.\n- stalled: all non-idle threads simultaneously waiting on `I/O`; no useful user code ran during these periods → true `I/O` thrashing.\n\nIf stalled > 0 while querying, it's recommended to increase queue depth on NVMe, raise blk-mq budgets, or relax cgroup I/O limits.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 68
+      },
+      "id": 74,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(process_pressure_io_waiting_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}: waiting",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(process_pressure_io_stalled_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}: stalled",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "IO pressure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Current number of active TCP connections to VictoriaLogs. This metric helps monitor connection pool usage and identify potential connection leaks. High values may indicate clients not properly closing connections or connection pooling issues. Monitor for gradual increases that could lead to resource exhaustion.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 76
+      },
+      "id": 60,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "TCP connections ($instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Rate of incoming TCP connections accepted by VictoriaLogs. This metric indicates network activity and client connection patterns. Sudden spikes may indicate increased load or potential DDoS attacks. Sustained high rates should be correlated with resource usage to ensure adequate capacity.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "id": 58,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(vm_tcplistener_accepts_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "TCP connections rate ($instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Percent of CPU spent on garbage collection.\n\nIf % is high, then CPU usage can be decreased by changing `GOGC` to higher values. Increasing `GOGC` value will increase memory usage, and decrease CPU usage.\n\nTry searching for keyword `GOGC` at https://docs.victoriametrics.com/victoriametrics/troubleshooting/ ",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 84
+      },
+      "id": 119,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(instance)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU spent on GC ($instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 84
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(go_goroutines{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines ($instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 92
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "max(process_num_threads{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Threads ($instance)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Time goroutines have spent in runnable state before actually running. The lower is better.\n\nHigh values or values exceeding the threshold is usually a sign of            insufficient CPU resources or CPU throttling. \n\nVerify that service has enough CPU resources. Otherwise, the service could work unreliably with delays in processing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 92
+      },
+      "id": 61,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(histogram_quantile(0.99, sum(rate(go_sched_latencies_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, le))) by (instance)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Go scheduling latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 100
+      },
+      "id": 68,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of restarts per job. The chart can be useful to identify periodic process restarts and correlate them with potential issues or anomalies. \n\nNormally, processes shouldn't restart unless restart was inited by user. The reason of restarts should be figured out by checking the logs of each specific service. ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "stepAfter",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 0,
+              "links": [],
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 157
+          },
+          "id": 62,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Restarts",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "The number of new [log streams](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) created over the last 24 hours. Lower rate is better. See [How to determine which fields must be associated with log streams?](https://docs.victoriametrics.com/victorialogs/keyconcepts/#how-to-determine-which-fields-must-be-associated-with-log-streams)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 157
+          },
+          "id": 26,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "max(increase(vl_streams_created_total{job=~\"$job\", instance=~\"$instance\"}[1d])) by (instance)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Streams churn rate 24h ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Flags explicitly set to non-default values",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "transparent",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "name"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "---------": {
+                            "color": "#292929",
+                            "index": 0
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "applyToRow": true,
+                      "mode": "basic",
+                      "type": "color-background"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 189
+          },
+          "id": 149,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "instance"
+              }
+            ]
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(flag{is_set=\"true\", job=~\"$job\", instance=~\"$instance\"}) by(instance, name, value)\nor\nlabel_replace(\n  label_replace(\n    sum(flag{is_set=\"true\", job=~\"$job\", instance=~\"$instance\"}) by(instance),\n    \"name\",  \"---------\", \"instance\", \"(.*)\"\n  ),\n  \"value\", \"---------\", \"instance\", \"(.*)\"\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "{{name}}={{value}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Non-default flags",
+          "transformations": [
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "instance": {
+                    "aggregations": [
+                      "uniqueValues"
+                    ],
+                    "operation": "groupby"
+                  },
+                  "job": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "name": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "value": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  }
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of log entries ignored or dropped on insertion due to the following reasons:\n* Timestamp out of the retention period or in the future\n* Number of fields per entry exceeded\n* Line too long\n\nIf this occurs, check the VictoriaLogs log for details.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 189
+          },
+          "id": 71,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(increase(vl_rows_dropped_total{job=~\"$job\", instance=~\"$instance\"}[1h])) by (reason) ",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{reason}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(vl_too_long_lines_skipped_total{job=~\"$job\", instance=~\"$instance\"}[1h]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "line_too_long",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Logs dropped for last 1h",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Troubleshooting",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 101
+      },
+      "id": 82,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of daily partitions currently stored on disk.\n\nVictoriaLogs stores data in daily partitions, so this roughly matches the number of days with data kept. It increases as new days arrive and decreases when retention removes older days.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 3,
+            "x": 0,
+            "y": 102
+          },
+          "id": 88,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(vl_partitions{job=~\"$job\", instance=~\"$instance\"})",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Partition Count",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of storage parts (data files) in each tier. More parts mean fragmentation; fewer parts suggest successful merging. High part counts may slow queries and trigger background merge operations.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 9,
+            "x": 3,
+            "y": 102
+          },
+          "id": 84,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(vl_storage_parts{job=~\"$job\", instance=~\"$instance\"}) by(type)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Part count max by type ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Disk space usage and limits for VictoriaLogs storage. Tracks current data usage against the configured retention limit and total disk space.\n\nThe orange line indicates the space retention limit. When usage approaches this limit, older data will be automatically deleted. If the space retention limit (`-retention.maxDiskSpaceUsageBytes`) is not specified, it won't show.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 1,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "max space retention of instances"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.insertNulls",
+                    "value": 3600000
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 102
+          },
+          "id": 147,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(\n  sum(max_over_time(vl_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)\n  / on (instance)\n  vl_total_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"}\n) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Disk ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of storage merge operations by type (sum across instances). Merges compact smaller parts into larger ones; bursts are normal after activity spikes.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 110
+          },
+          "id": 112,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(increase(vl_merges_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(type)",
+              "hide": false,
+              "interval": "$__rate_interval",
+              "legendFormat": "{{type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Merge events",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "99th percentile duration of merge operations by storage type. Merge operations combine smaller storage parts into larger ones for optimization. \n\nNormal merge durations vary by storage type and data volume. Consistently high durations may indicate storage performance issues, high write load, or insufficient resources for background operations. Monitor for trends that could impact overall system performance.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 110
+          },
+          "id": 86,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(vl_merge_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (type)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Merge duration p99 ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "99th percentile of data volume processed during merge operations by storage type. \n\nThis metric indicates the scale of background storage optimization activities. Larger merge sizes generally improve storage efficiency but require more resources. Consistently high values may indicate heavy write loads or large storage parts that need optimization. Monitor correlation with merge duration for performance insights.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 118
+          },
+          "id": 109,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(vl_merge_bytes{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (type)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Merge bytes p99 ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of log rows waiting to be written to storage, categorized by type. Pending rows indicate temporary queuing during ingestion. Consistently high values may suggest storage write bottlenecks or insufficient write capacity.\n\nPending rows are flushed in two ways:\n\n- After a specific time period (typically 1 second)\n- When the pending row size exceeds a threshold (typically 1.75 MB)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 118
+          },
+          "id": 148,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(vl_pending_rows{job=~\"$job\", instance=~\"$instance\"}) by (type)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Pending rows ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Shows whether the VictoriaLogs instance is in read-only mode.\nValue is 1 when storage is read-only (free disk space below `-storage.minFreeDiskSpaceBytes`), otherwise 0.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 1,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 126
+          },
+          "id": 150,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(max_over_time(vl_storage_is_read_only{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Storage read-only ($instance)",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Storage",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 102
+      },
+      "id": 83,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "How fast logs are coming in.\n\nThis shows the ingestion rate, split by source type (for example: Loki, Elasticsearch, syslog). You'll see both:\n- events per second\n- estimated data volume per second\n\nIf this suddenly spikes, expect higher CPU and disk usage. If it drops to near zero, check upstream shippers/agents and this cluster's insert health.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*(bytes)/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 625
+          },
+          "id": 113,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) ",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{type}} (bytes)",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Logs ingestion rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 625
+          },
+          "id": 117,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\",path=~\"^/(internal/)?insert.*\"}[$__rate_interval])) by (path)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{path}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Request rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "99th percentile of insert operation duration. This represents the time it takes for 99% of insert operations to complete. High values indicate slow ingestion performance that could affect overall system throughput. Spikes may suggest storage bottlenecks, resource contention, or inefficient data processing.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 633
+          },
+          "id": 103,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\", path=~\"^/(internal/)?insert.*\"}) by (path)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{path}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Insert duration p99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "99th percentile response time for VictoriaLogs HTTP endpoints, grouped by instance and path. This means 99% of requests are faster than this value. **Lower numbers are better**, as they indicate faster responses and fewer slow requests.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 633
+          },
+          "id": 116,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\", path=~\"^/(internal/)?insert.*\"}) by (path)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{path}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Request duration p99 ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of active message processors handling log ingestion. These processors parse and process incoming log messages before storage.\n\nThe `soft limit` line is the configured concurrency limit for insert request processing (`-maxConcurrentInserts`). It is marked as soft because streaming/slow clients may keep many HTTP requests in-flight while only a limited number of them are actively processed at the same time.\n\nIf processors are consistently high, correlate with ingestion rate and memory/CPU usage. Sudden growth may indicate burst traffic, slow clients/network, or backpressure from storage nodes.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 0,
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 641
+          },
+          "id": 97,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "max(max_over_time(vl_insert_processors_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "max(max_over_time(vm_concurrent_insert_capacity{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "soft limit",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Message processors ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of log rows waiting to be written to storage, categorized by type. Pending rows indicate temporary queuing during ingestion. Consistently high values may suggest storage write bottlenecks or insufficient write capacity.\n\nPending rows are flushed in two ways:\n\n- After a specific time period (typically 1 second)\n- When the pending row size exceeds a threshold (typically 1.75 MB)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 641
+          },
+          "id": 104,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "max(vl_pending_rows{job=~\"$job\", instance=~\"$instance\"}) by (type)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Max pending rows ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Insert requests that hit the ingestion concurrency limit and had to wait in a queue (per time interval).\n\nVictoriaLogs limits the number of concurrent insert requests with `-maxConcurrentInserts`. This protects the server from too many simultaneous in-flight inserts.\n\nIf this is frequently above zero, ingestion is under pressure. A common reason is slow client networks (requests take longer, so they occupy concurrency slots longer). In that case, increasing `-maxConcurrentInserts` can help if the server still has CPU headroom. If CPU is already saturated, prefer scaling out insert nodes and/or reducing client-side parallelism/batch size instead.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 649
+          },
+          "id": 143,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "max(increase(vm_concurrent_insert_limit_reached_total[$__rate_interval])) by (instance)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Concurrent insert limit reached ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of insert requests that timed out while waiting for available concurrency slots. This indicates sustained ingestion overload beyond configured limits.\n\nHigh values suggest:\n- Insert queue is consistently full\n- Insert requests waiting too long for execution slots\n- System under sustained heavy ingestion load\n- Need for horizontal scaling or ingestion optimization\n\nCombined with `Insert concurrency limit reached`, provides complete picture of ingestion rejection patterns.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 649
+          },
+          "id": 131,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(vm_concurrent_insert_limit_timeout_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Insert timeouts ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "99th percentile duration of background flush operations by type. High values may indicate disk pressure or heavy ingestion. Correlate with `I/O` panels.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 657
+          },
+          "id": 115,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(vl_insert_flush_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (type)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Flush duration p99",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Ingestion",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 103
+      },
+      "id": 81,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 859
+          },
+          "id": 102,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\",path=~\"^/(internal/)?select.*\"}[$__rate_interval])) by (path)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{path}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Query rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "99th percentile of query execution duration. This represents the time it takes for 99% of queries to complete:\n\n- High values indicate slow query performance that affects user experience. \n- Spikes may suggest complex queries, resource contention, or inefficient indexes. Monitor for trends that could indicate degrading performance.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 859
+          },
+          "id": 108,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\", path=~\"^/(internal/)?select.*\"}) by (path)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{path}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Query duration p99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of concurrent select (query) operations compared to the configured limit.\n\nHigh utilization near the limit may indicate query bottlenecks or insufficient query processing capacity.\n\nIf it's consistently high while CPU usage remains low, consider increasing the concurrency limit (`-search.maxConcurrentRequests`) or optimizing query performance to support more concurrent users.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "limit"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 899
+          },
+          "id": 107,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "max(max_over_time(vl_concurrent_select_current{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "max(max_over_time(vl_concurrent_select_capacity{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "limit",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Concurrent queries ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of queries that timed out while waiting for available concurrency slots. This indicates sustained query overload beyond configured limits.\n\nHigh values suggest:\n- Query queue is consistently full\n- Queries waiting too long for execution slots\n- System under sustained heavy load\n- Need for horizontal scaling or query optimization\n\nCombined with `Select concurrency limit reached`, provides complete picture of query rejection patterns.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 899
+          },
+          "id": 132,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(vl_concurrent_select_limit_timeout_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Query timeouts ($instance)",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Querying",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 104
+      },
+      "id": 126,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of storage blocks scanned per query (99th percentile). Each block contains logs for a single log stream over some time range.\n\nHigh values usually mean the query has to consider many blocks, for example because:\n- The time range is wide\n- The query doesn’t narrow down log streams (e.g. no good stream filter)\n- The filters are not selective and cannot quickly skip blocks\n\nCorrelate with `Bytes/query p99`: if blocks are high but bytes are low, each block contributes little data (often OK). If both are high, the query is reading a lot of data from storage.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 860
+          },
+          "id": 130,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_processed_blocks_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Blocks/query p99 ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Total bytes read from disk per query (99th percentile). This represents the complete `I/O` overhead for query execution, including:\n\n- Block headers and metadata\n- Bloom filter data for candidate selection\n- Column headers and indexes\n- Actual log values and timestamps\n\nHigh values indicate expensive queries. Compare with specific breakdown panels below to identify bottlenecks. Monitor trends over time and correlate with query complexity.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 860
+          },
+          "id": 121,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_total_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes/query p99 ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Bytes read from block headers per query (99th percentile). Block headers contain metadata about each storage block including `time ranges`, `field names`, and data location pointers.\n\nHigh values indicate:\n- Query `time range` spans many blocks (reduce time range or add time-based filters)\n- Missing stream-level filters (`_stream` field) causing full block header scans\n- High cardinality fields creating excessive blocks\n\nMonitor relative changes over time - sudden increases suggest inefficient query patterns or changes in data structure.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 868
+          },
+          "id": 124,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_block_headers_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance) > 0.001",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block header bytes/query p99 ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Bytes read from Bloom filters per query (99th percentile). `Bloom filters` are probabilistic data structures that quickly eliminate blocks that definitely don't contain search terms.\n\nHigh values indicate:\n- Queries with low-selectivity text filters (common words like `error`, `info`)\n- Missing or ineffective field-based filters\n- Queries that force scanning many candidate blocks\n\nOptimize by adding specific field filters (`kubernetes.container_name`, `_stream`) before text searches. Monitor for sudden increases that indicate poor filter selectivity.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 868
+          },
+          "id": 129,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_bloom_filters_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance) > 0.001",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Bloom filter bytes/query p99 ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Bytes read from log values per query (99th percentile). This measures storage I/O spent on reading field values (not metadata like headers/bloom filters).\n\nHigh values indicate queries that have to fetch lots of log content from disk, for example because:\n- The time range is wide or filters are not selective\n- The query matches many logs\n- Logs have large payloads (large messages / JSON blobs / stack traces)\n\nIf you want to understand how much data was processed after decompression/decoding (CPU work), compare with the corresponding “uncompressed values processed bytes” metric/panel.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 876
+          },
+          "id": 122,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_values_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Value bytes/query p99 ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Bytes read from the `_time` field per query (99th percentile). The `_time` field is used to narrow queries to the selected time range.\n\nHigh values usually mean the query spans a wide time range and/or touches many blocks, so more timestamp data needs to be read.\n\nThis is typically a smaller part of total query I/O compared to reading log values, so correlate with `Bytes/query p99` and `Value bytes/query p99` when investigating slow queries.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 876
+          },
+          "id": 127,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_timestamps_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "_time bytes/query p99 ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Bytes read from column header indexes per query (99th percentile). `Column header indexes` contain metadata about which fields exist in each block and their data types.\n\nHigh values suggest:\n- Queries scanning many blocks due to missing field filters\n- High field cardinality creating large index structures\n- Queries accessing many different field names across blocks\n- Schema evolution causing index fragmentation\n\nOptimize by using consistent `field names` and adding field-specific filters early in query pipeline.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 884
+          },
+          "id": 128,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_columns_header_indexes_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Column header index bytes/query p99 ($instance)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Bytes read from column headers per query (99th percentile). `Column headers` store the actual field schema and compression metadata for each block's columns.\n\nThis metric helps identify:\n- Schema complexity overhead (many fields per log entry)\n- Inefficient field access patterns\n- Blocks with heterogeneous schemas requiring header reads\n\nCompare with other `I/O` breakdown panels to understand query cost distribution. High column header reads suggest schema optimization opportunities or need for more selective field access patterns.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic-by-name"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 884
+          },
+          "id": 123,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_columns_headers_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Column header bytes/query p99 ($instance)",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Slow Query Troubleshooting",
+      "type": "row"
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 42,
+  "tags": [
+    "victoriametrics",
+    "victorialogs"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "",
+          "value": "${DS_PROMETHEUS}",
+          "selected": true
+        },
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$DS_PROMETHEUS"
+        },
+        "definition": "label_values(vm_app_version{version=~\"victoria-logs-.*\"}, job)",
+        "includeAll": true,
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(vm_app_version{version=~\"victoria-logs-.*\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$DS_PROMETHEUS"
+        },
+        "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
+        "includeAll": true,
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(vm_app_version{job=~\"$job\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$DS_PROMETHEUS"
+        },
+        "definition": "label_values(vm_app_version{job=~\"$job\", instance=~\"$instance\"},short_version)",
+        "hide": 2,
+        "name": "version",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(vm_app_version{job=~\"$job\", instance=~\"$instance\"},short_version)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "baseFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$DS_PROMETHEUS"
+        },
+        "filters": [],
+        "name": "adhoc",
+        "type": "adhoc"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "VictoriaLogs - single-node",
+  "uid": "OqPIZTX4z",
+  "version": 9,
+  "weekStart": "",
+  "id": null
+}

--- a/docker-compose/victorialogs/monitoring/nightingale/victorialogs-v1.52.0.json
+++ b/docker-compose/victorialogs/monitoring/nightingale/victorialogs-v1.52.0.json
@@ -1,0 +1,4122 @@
+{
+  "name": "VictoriaLogs 生产监控（官方 v1.52.0 单机版）",
+  "tags": "victorialogs production official v1.52.0",
+  "note": "VictoriaMetrics 官方随 VictoriaLogs v1.52.0 发布的单机监控大屏；73 个面板覆盖可用性、写入、查询、丢弃、存储、合并、CPU、内存、磁盘 I/O 与进程状态。仅将 Grafana table 面板转换为夜莺原生 barGauge。",
+  "ident": "victorialogs-production-monitoring",
+  "uuid": 1788508003000001,
+  "configs": {
+    "version": "3.4.0",
+    "links": [
+      {
+        "title": "Docs",
+        "url": "https://docs.victoriametrics.com/victorialogs/",
+        "targetBlank": true
+      },
+      {
+        "title": "Community support",
+        "url": "https://victoriametrics.com/support/community-support/",
+        "targetBlank": true
+      },
+      {
+        "title": "Enterprise support",
+        "url": "https://victoriametrics.com/support/enterprise-support/",
+        "targetBlank": true
+      },
+      {
+        "title": "Releases",
+        "url": "https://github.com/VictoriaMetrics/VictoriaLogs/releases",
+        "targetBlank": true
+      }
+    ],
+    "var": [
+      {
+        "type": "datasource",
+        "name": "DS_PROMETHEUS",
+        "definition": "prometheus",
+        "label": "数据源"
+      },
+      {
+        "type": "query",
+        "name": "job",
+        "allOption": true,
+        "multi": true,
+        "reg": "",
+        "hide": true,
+        "definition": "label_values(vm_app_version{version=~\"victoria-logs-.*\"}, job)",
+        "datasource": {
+          "cate": "prometheus",
+          "value": "${DS_PROMETHEUS}"
+        }
+      },
+      {
+        "type": "query",
+        "name": "instance",
+        "allOption": true,
+        "multi": true,
+        "reg": "",
+        "hide": true,
+        "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
+        "datasource": {
+          "cate": "prometheus",
+          "value": "${DS_PROMETHEUS}"
+        }
+      },
+      {
+        "type": "query",
+        "name": "version",
+        "reg": "",
+        "hide": true,
+        "definition": "label_values(vm_app_version{job=~\"$job\", instance=~\"$instance\"},short_version)",
+        "datasource": {
+          "cate": "prometheus",
+          "value": "${DS_PROMETHEUS}"
+        }
+      }
+    ],
+    "panels": [
+      {
+        "version": "3.4.0",
+        "id": "08e22c08-53e0-423b-87db-175d95c747c0",
+        "type": "row",
+        "name": "Stats",
+        "collapsed": true,
+        "layout": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0,
+          "i": "08e22c08-53e0-423b-87db-175d95c747c0"
+        },
+        "panels": []
+      },
+      {
+        "version": "3.4.0",
+        "id": "8b28f165-8652-4cb8-8dc6-c1cfc0e0f223",
+        "type": "stat",
+        "name": "Total log entries",
+        "description": "Total amount of log entries in the storage.",
+        "links": [],
+        "layout": {
+          "h": 4,
+          "w": 5,
+          "x": 0,
+          "y": 1,
+          "i": "8b28f165-8652-4cb8-8dc6-c1cfc0e0f223"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(vl_storage_rows{job=~\"$job\", instance=~\"$instance\"})",
+            "legend": "total"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none"
+          },
+          "legend": {
+            "displayMode": "list"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "value",
+          "calc": "lastNotNull",
+          "colorMode": "value"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "8b015062-85fd-4cb0-9e1c-a2639e283455",
+        "type": "stat",
+        "name": "Ingested logs 24h",
+        "description": "The total number of log entries ingested over the past 24 hours.",
+        "links": [],
+        "layout": {
+          "h": 4,
+          "w": 5,
+          "x": 5,
+          "y": 1,
+          "i": "8b015062-85fd-4cb0-9e1c-a2639e283455"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(increase(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[24h]))",
+            "legend": "total"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none"
+          },
+          "legend": {
+            "displayMode": "list"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "value",
+          "calc": "lastNotNull",
+          "colorMode": "value"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "619c3e0f-0b05-4910-abfa-ccc1f48451d9",
+        "type": "stat",
+        "name": "Insert req/s",
+        "description": "Average ingestion rate of log entries.",
+        "links": [],
+        "layout": {
+          "h": 4,
+          "w": 4,
+          "x": 10,
+          "y": 1,
+          "i": "619c3e0f-0b05-4910-abfa-ccc1f48451d9"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+            "legend": "total"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none"
+          },
+          "legend": {
+            "displayMode": "list"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "value",
+          "calc": "lastNotNull",
+          "colorMode": "value"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "43bafea5-84f0-49da-9f91-d7d80b7f67b1",
+        "type": "stat",
+        "name": "Disk space usage",
+        "description": "Total amount of used disk space.\nAccounts for all compressed log entries and index size.\n\nSee how to [control disk usage](https://docs.victoriametrics.com/victorialogs/#retention-by-disk-space-usage).",
+        "links": [],
+        "layout": {
+          "h": 4,
+          "w": 5,
+          "x": 14,
+          "y": 1,
+          "i": "43bafea5-84f0-49da-9f91-d7d80b7f67b1"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(vl_data_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
+            "legend": "total"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "bytesIEC"
+          },
+          "legend": {
+            "displayMode": "list"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "value",
+          "calc": "lastNotNull",
+          "colorMode": "value"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "ac31dc02-d98d-4bd2-b386-e338bee01d2d",
+        "type": "stat",
+        "name": "Available CPU",
+        "description": "Integer number of CPU cores available to the application. This value is automatically rounded down from fractional CPU quotas. For optimal performance, fractional CPU units should be avoided. See the [best practices](https://docs.victoriametrics.com/victoriametrics/bestpractices/#kubernetes) documentation for more details.",
+        "links": [],
+        "layout": {
+          "h": 4,
+          "w": 5,
+          "x": 19,
+          "y": 1,
+          "i": "ac31dc02-d98d-4bd2-b386-e338bee01d2d"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(vm_available_cpu_cores{job=~\"$job\", instance=~\"$instance\"})",
+            "legend": "total"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none"
+          },
+          "legend": {
+            "displayMode": "list"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "value",
+          "calc": "lastNotNull",
+          "colorMode": "value"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "7876a114-b89a-47e5-8dbe-99dffee405fa",
+        "type": "stat",
+        "name": "Total ingested size (uncompressed)",
+        "description": "Total log data (uncompressed) currently stored and still present in the system. This excludes data removed by retention or detached partitions.",
+        "links": [],
+        "layout": {
+          "h": 4,
+          "w": 5,
+          "x": 0,
+          "y": 5,
+          "i": "7876a114-b89a-47e5-8dbe-99dffee405fa"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(vl_uncompressed_data_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
+            "legend": "total"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "bytesIEC"
+          },
+          "legend": {
+            "displayMode": "list"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "value",
+          "calc": "lastNotNull",
+          "colorMode": "value"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "595f501d-64d9-4688-8f32-a6abe727becf",
+        "type": "stat",
+        "name": "Ingested bytes 24h",
+        "description": "The cumulative number of log entries ingested over the last 24h. \n\nThe size is calculated before compression.",
+        "links": [],
+        "layout": {
+          "h": 4,
+          "w": 5,
+          "x": 5,
+          "y": 5,
+          "i": "595f501d-64d9-4688-8f32-a6abe727becf"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(increase(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[24h]))",
+            "legend": "total"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "bytesIEC"
+          },
+          "legend": {
+            "displayMode": "list"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "value",
+          "calc": "lastNotNull",
+          "colorMode": "value"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "8c97a384-1188-4de6-9cf0-80b016cbb379",
+        "type": "stat",
+        "name": "Read req/s",
+        "description": "Rate of HTTP read requests.",
+        "links": [],
+        "layout": {
+          "h": 4,
+          "w": 4,
+          "x": 10,
+          "y": 5,
+          "i": "8c97a384-1188-4de6-9cf0-80b016cbb379"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\", path=~\"/select/.*\"}[$__rate_interval]))",
+            "legend": "total"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none"
+          },
+          "legend": {
+            "displayMode": "list"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "value",
+          "calc": "lastNotNull",
+          "colorMode": "value"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "b3a40418-6192-4b8f-8d44-66c11f6b3396",
+        "type": "stat",
+        "name": "Compression ratio",
+        "description": "The ratio between original data size and compressed data stored on disk. This metric excludes indexdb size. \n\nThe ratio can go up or down as the system performs automatic maintenance and applies retention policies. For examples:\n- Background merges: [Merges](https://docs.victoriametrics.com/victorialogs/#forced-merge) improve compression by combining data into larger, more efficiently compressed blocks\n- Retention policies: When old data is deleted due to retention settings, the ratio changes as different time periods have varying compression characteristics\n\n",
+        "links": [],
+        "layout": {
+          "h": 4,
+          "w": 5,
+          "x": 14,
+          "y": 5,
+          "i": "b3a40418-6192-4b8f-8d44-66c11f6b3396"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": " sum(vl_uncompressed_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) / sum(vl_compressed_data_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none"
+          },
+          "legend": {
+            "displayMode": "list"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "value",
+          "calc": "lastNotNull",
+          "colorMode": "value"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "d0913cc9-e0cc-45c0-a0e6-a82cb753563f",
+        "type": "stat",
+        "name": "Available memory",
+        "description": "Total system memory available to the application. This represents the system or container's memory capacity or limit, not the currently free memory.",
+        "links": [],
+        "layout": {
+          "h": 4,
+          "w": 5,
+          "x": 19,
+          "y": 5,
+          "i": "d0913cc9-e0cc-45c0-a0e6-a82cb753563f"
+        },
+        "targets": [],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "bytesIEC"
+          },
+          "legend": {
+            "displayMode": "list"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "textMode": "value",
+          "calc": "lastNotNull",
+          "colorMode": "value"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "41ed7574-fb1d-4ac4-b697-7edd999313fc",
+        "type": "row",
+        "name": "Overview",
+        "collapsed": true,
+        "layout": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 9,
+          "i": "41ed7574-fb1d-4ac4-b697-7edd999313fc"
+        },
+        "panels": []
+      },
+      {
+        "version": "3.4.0",
+        "id": "67080596-14c8-49ea-93d5-08a12b1598f6",
+        "type": "timeseries",
+        "name": "Logs ingestion rate",
+        "description": "Ingestion rate in number of log entries and bytes per second.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 10,
+          "i": "67080596-14c8-49ea-93d5-08a12b1598f6"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type)",
+            "legend": "{{type}}"
+          },
+          {
+            "refId": "B",
+            "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type)",
+            "legend": "{{type}} (bytes)"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none",
+            "min": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "69b5fd18-7755-4440-bbc2-b63b64f8b896",
+        "type": "timeseries",
+        "name": "Requests rate",
+        "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 10,
+          "i": "69b5fd18-7755-4440-bbc2-b63b64f8b896"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path)",
+            "legend": "{{path}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none",
+            "min": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "4fb414e5-2312-43da-a816-6286743ca72d",
+        "type": "timeseries",
+        "name": "Requests error rate",
+        "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 18,
+          "i": "4fb414e5-2312-43da-a816-6286743ca72d"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path, reason)",
+            "legend": "{{path}} - {{reason}}"
+          },
+          {
+            "refId": "B",
+            "expr": "sum(rate(vl_http_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path)",
+            "legend": "{{path}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none",
+            "min": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "d3481091-6fda-44a9-8071-a2e97b8c5067",
+        "type": "timeseries",
+        "name": "Request duration p99",
+        "description": "Tail latency of VictoriaLogs HTTP endpoints, split by request `path` (seconds).\n\nThis shows the p99 response time, i.e. the slowest 1% of requests. It is the first place to look when users report 'slow queries' or 'slow ingestion'.\n\nBecause the chart takes the maximum across the selected instances, a single unhealthy node will stand out. If you see spikes, correlate with error rate and resource panels (CPU, memory, I/O pressure) to decide whether it is client load, a slow node, or storage pressure.\n\n`/internal/*` endpoints are excluded.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 18,
+          "i": "d3481091-6fda-44a9-8071-a2e97b8c5067"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (path)",
+            "legend": "{{path}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "seconds",
+            "min": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "183666f8-4038-40fc-9d5e-9e2b4cb8e569",
+        "type": "timeseries",
+        "name": "Disk space usage",
+        "description": "Total amount of used disk space.\nAccounts for all compressed log entries and index size.\n\nSee how to [control disk usage](https://docs.victoriametrics.com/victorialogs/#retention-by-disk-space-usage).",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 26,
+          "i": "183666f8-4038-40fc-9d5e-9e2b4cb8e569"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(vl_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "bytesIEC",
+            "min": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "a65931c1-cea4-454b-933b-513f0436c124",
+        "type": "timeseries",
+        "name": "VictoriaLogs internal logging",
+        "description": "Rate of VictoriaLogs' own application log messages (debug, warnings, errors) - NOT the logs that VictoriaLogs is collecting from external sources.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 26,
+          "i": "a65931c1-cea4-454b-933b-513f0436c124"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[$__rate_interval])) by (instance, level, app_version, location)",
+            "legend": "{{instance}} - {{level}}: {{location}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none"
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "c18f4aec-e3a3-4ba3-a8e3-829e6fac4cdc",
+        "type": "row",
+        "name": "Resource usage",
+        "collapsed": true,
+        "layout": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 34,
+          "i": "c18f4aec-e3a3-4ba3-a8e3-829e6fac4cdc"
+        },
+        "panels": []
+      },
+      {
+        "version": "3.4.0",
+        "id": "44306d6f-24dd-4398-8135-4cef81a4ac6e",
+        "type": "timeseries",
+        "name": "Total memory % usage ($instance)",
+        "description": "How much memory (RAM) the VictoriaLogs process is actually using, compared to its allowed container or system limit. See 'Memory Usage' panel for a detailed breakdown.\n\n- Good: Below 70% most of the time, maybe spiking a bit under load.\n- Bad: Above 90% for more than 5 minutes = risk of out-of-memory (`OOM`) kill.",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 35,
+          "i": "44306d6f-24dd-4398-8135-4cef81a4ac6e"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(\n    max_over_time(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n    /\n    process_memory_limit_bytes{job=~\"$job\", instance=~\"$instance\"}\n) by (instance)",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "percentUnit",
+            "min": 0,
+            "max": 1
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "6f7a4f98-a548-4e88-8314-07e5623b0b3a",
+        "type": "timeseries",
+        "name": "Anonymous memory % usage ($instance)",
+        "description": "",
+        "links": [],
+        "layout": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 35,
+          "i": "6f7a4f98-a548-4e88-8314-07e5623b0b3a"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(\n    max_over_time(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n    /\n    process_memory_limit_bytes{job=~\"$job\", instance=~\"$instance\"}\n) by (instance)",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "percentUnit",
+            "min": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "68336b99-7f5a-4c79-840c-1e05902b7d33",
+        "type": "timeseries",
+        "name": "Memory allocations rate",
+        "description": "Rate of allocations in memory. Sudden increase in allocations would mean increased pressure on Go Garbage Collector and can saturate CPU resources of the application.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 44,
+          "i": "68336b99-7f5a-4c79-840c-1e05902b7d33"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[$__rate_interval])) by (job)",
+            "legend": "{{job}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "bytesIEC",
+            "min": 0,
+            "decimals": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "852e2b3e-cf25-440d-9314-ea197bd14afa",
+        "type": "timeseries",
+        "name": "Memory pressure",
+        "description": "Lower is better, e.g. 20% means the process was delayed by memory pressure 20% of the time. See [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\n- waiting: Time fraction where at least one thread was blocked on memory.\n- stalled: Time fraction where every thread was blocked on memory (severe pressure).\n\nIf queries slow down and both series spike, the host is likely limited by RAM or I/O throughput.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 44,
+          "i": "852e2b3e-cf25-440d-9314-ea197bd14afa"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(rate(process_pressure_memory_waiting_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+            "legend": "{{instance}} - waiting"
+          },
+          {
+            "refId": "B",
+            "expr": "sum(rate(process_pressure_memory_stalled_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+            "legend": "{{instance}} - stalled"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 0.2
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "percentUnit",
+            "min": 0,
+            "max": 1,
+            "decimals": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "fc26931a-e116-429f-8a59-0c1c8bf6773f",
+        "type": "timeseries",
+        "name": "CPU % usage ($instance)",
+        "description": "CPU utilization per instance as a fraction of available cores. Sustained values above 80% indicate CPU saturation; correlate with CPU PSI and query latency.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 52,
+          "i": "fc26931a-e116-429f-8a59-0c1c8bf6773f"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(\n    rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n    /\n    process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}\n) by(instance)",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "percentUnit",
+            "min": 0,
+            "max": 1
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "5ea0234f-0175-428e-b906-6c092a9ed151",
+        "type": "timeseries",
+        "name": "CPU pressure",
+        "description": "Helps troubleshoot high CPU usage or throttling:\n\n- waiting: The percentage of time at least one task in the VictoriaLogs process was ready to run (runnable) but couldn't get scheduled on the CPU.\n- stalled: The percentage of time all tasks in the process (except idle ones) were unable to get CPU time — a full CPU stall.\n\nIf there's a CPU burst, it's normal to see waiting or stalled > 1%. It only becomes a concern if it consistently climbs above 5–10% and aligns with latency spikes or GC slowdowns.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 52,
+          "i": "5ea0234f-0175-428e-b906-6c092a9ed151"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(rate(process_pressure_cpu_waiting_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+            "legend": "{{instance}} - waiting"
+          },
+          {
+            "refId": "B",
+            "expr": "max(rate(process_pressure_cpu_stalled_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+            "legend": "{{instance}} - stalled"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "percentUnit",
+            "min": 0,
+            "decimals": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "6c4e3fc6-69cf-4c2d-b0b2-72308a702e3c",
+        "type": "timeseries",
+        "name": "Disk writes/reads ($instance)",
+        "description": "Measure the actual bytes read from and written to disk by the process:\n\n- read: physical bytes the kernel actually pulled from the storage device on behalf of the process (after checking page-cache).\n- write: physical bytes the kernel ultimately wrote to the storage device for the process (after combining, caching, or delaying writes).",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 60,
+          "i": "6c4e3fc6-69cf-4c2d-b0b2-72308a702e3c"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+            "legend": "read"
+          },
+          {
+            "refId": "C",
+            "expr": "max(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+            "legend": "write"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "bytesIEC"
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "b46d9a1d-46a2-4224-8bd5-62c52bd37447",
+        "type": "timeseries",
+        "name": "Storage read/write syscalls ($instance)",
+        "description": "Number of read/write calls application makes:\n\n- read call: Number of read*()-family system calls your process has issued since start. Each call can move 1 byte or megabytes, cached or uncached.\n- write call: Number of write*()-family system calls (including write, pwrite, writev, etc.) made by the process.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 60,
+          "i": "b46d9a1d-46a2-4224-8bd5-62c52bd37447"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(rate(process_io_read_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+            "legend": "read calls"
+          },
+          {
+            "refId": "B",
+            "expr": "max(rate(process_io_write_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+            "legend": "write calls"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none"
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "e54f9017-45a6-4b80-88a1-c271f92f6661",
+        "type": "timeseries",
+        "name": "Open FDs % usage ($instance)",
+        "description": "Percentage of open file descriptors (files, sockets, pipes, etc.,) compared to the limit set in the OS. Reaching the limit of open files can cause various issues and must be prevented.\n\nSee [how to change limits](https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a).",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 68,
+          "i": "e54f9017-45a6-4b80-88a1-c271f92f6661"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max_over_time(process_open_fds{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n/\nprocess_max_fds{job=~\"$job\", instance=~\"$instance\"}",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "percentUnit",
+            "min": 0,
+            "decimals": 2
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "f9f5aeba-da88-41b8-a555-b6122b2d05fa",
+        "type": "timeseries",
+        "name": "IO pressure",
+        "description": "IO pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html). The lower the better.\n\n- waiting: at least one runnable thread blocked on block-`I/O` (disk, NVMe, network-storage) while others could still make progress.\n- stalled: all non-idle threads simultaneously waiting on `I/O`; no useful user code ran during these periods → true `I/O` thrashing.\n\nIf stalled > 0 while querying, it's recommended to increase queue depth on NVMe, raise blk-mq budgets, or relax cgroup I/O limits.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 68,
+          "i": "f9f5aeba-da88-41b8-a555-b6122b2d05fa"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(rate(process_pressure_io_waiting_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+            "legend": "{{instance}}: waiting"
+          },
+          {
+            "refId": "B",
+            "expr": "max(rate(process_pressure_io_stalled_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+            "legend": "{{instance}}: stalled"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "percentUnit",
+            "min": 0,
+            "decimals": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "e0dc3bde-3abd-4305-b2c2-d28ba5b8b52a",
+        "type": "timeseries",
+        "name": "TCP connections ($instance)",
+        "description": "Current number of active TCP connections to VictoriaLogs. This metric helps monitor connection pool usage and identify potential connection leaks. High values may indicate clients not properly closing connections or connection pooling issues. Monitor for gradual increases that could lead to resource exhaustion.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 76,
+          "i": "e0dc3bde-3abd-4305-b2c2-d28ba5b8b52a"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none",
+            "min": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "98050c40-af26-4f91-872a-d56b5814c4b1",
+        "type": "timeseries",
+        "name": "TCP connections rate ($instance)",
+        "description": "Rate of incoming TCP connections accepted by VictoriaLogs. This metric indicates network activity and client connection patterns. Sudden spikes may indicate increased load or potential DDoS attacks. Sustained high rates should be correlated with resource usage to ensure adequate capacity.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 76,
+          "i": "98050c40-af26-4f91-872a-d56b5814c4b1"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(rate(vm_tcplistener_accepts_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none",
+            "min": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "56cc8f18-f64a-4daf-b5cc-34c59bd525f5",
+        "type": "timeseries",
+        "name": "CPU spent on GC ($instance)",
+        "description": "Percent of CPU spent on garbage collection.\n\nIf % is high, then CPU usage can be decreased by changing `GOGC` to higher values. Increasing `GOGC` value will increase memory usage, and decrease CPU usage.\n\nTry searching for keyword `GOGC` at https://docs.victoriametrics.com/victoriametrics/troubleshooting/ ",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 84,
+          "i": "56cc8f18-f64a-4daf-b5cc-34c59bd525f5"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(instance)",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "percentUnit",
+            "min": 0,
+            "decimals": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "eca6c19a-deb7-42cd-95f7-fbb00d9fe5ca",
+        "type": "timeseries",
+        "name": "Goroutines ($instance)",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 84,
+          "i": "eca6c19a-deb7-42cd-95f7-fbb00d9fe5ca"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(go_goroutines{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none",
+            "min": 0,
+            "decimals": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "b2d6d302-c553-400d-bd76-88346d2d7e82",
+        "type": "timeseries",
+        "name": "Threads ($instance)",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 92,
+          "i": "b2d6d302-c553-400d-bd76-88346d2d7e82"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "max(process_num_threads{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "off",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 80
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "none",
+            "min": 0,
+            "decimals": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "none"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "924436d9-15d6-4767-a484-6d99273134e7",
+        "type": "timeseries",
+        "name": "Go scheduling latency",
+        "description": "Time goroutines have spent in runnable state before actually running. The lower is better.\n\nHigh values or values exceeding the threshold is usually a sign of            insufficient CPU resources or CPU throttling. \n\nVerify that service has enough CPU resources. Otherwise, the service could work unreliably with delays in processing.",
+        "links": [],
+        "layout": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 92,
+          "i": "924436d9-15d6-4767-a484-6d99273134e7"
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(histogram_quantile(0.99, sum(rate(go_sched_latencies_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, le))) by (instance)",
+            "legend": "{{instance}}"
+          }
+        ],
+        "options": {
+          "valueMappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "style": "line",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": 0
+              },
+              {
+                "color": "#F2495C",
+                "value": 0.1
+              }
+            ]
+          },
+          "standardOptions": {
+            "util": "seconds",
+            "min": 0,
+            "decimals": 0
+          },
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "all",
+            "sort": "desc"
+          }
+        },
+        "custom": {
+          "version": "3.4.0",
+          "drawStyle": "lines",
+          "lineInterpolation": "linear",
+          "fillOpacity": 0,
+          "stack": "off"
+        },
+        "maxPerRow": 4,
+        "datasourceCate": "prometheus",
+        "datasourceValue": "${DS_PROMETHEUS}"
+      },
+      {
+        "version": "3.4.0",
+        "id": "f32fc066-d37f-4bb4-9a9a-9ec36d06bf1b",
+        "type": "row",
+        "name": "Troubleshooting",
+        "collapsed": false,
+        "layout": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 100,
+          "i": "f32fc066-d37f-4bb4-9a9a-9ec36d06bf1b"
+        },
+        "panels": [
+          {
+            "version": "3.4.0",
+            "id": "a63ca1bb-3cde-45fc-8c69-dcc7bc7d950b",
+            "type": "timeseries",
+            "name": "Restarts",
+            "description": "Number of restarts per job. The chart can be useful to identify periodic process restarts and correlate them with potential issues or anomalies. \n\nNormally, processes shouldn't restart unless restart was inited by user. The reason of restarts should be figured out by checking the logs of each specific service. ",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 157,
+              "i": "a63ca1bb-3cde-45fc-8c69-dcc7bc7d950b"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "decimals": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "93690da4-c286-47bd-bd89-5463622c1f5f",
+            "type": "timeseries",
+            "name": "Streams churn rate 24h ($instance)",
+            "description": "The number of new [log streams](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) created over the last 24 hours. Lower rate is better. See [How to determine which fields must be associated with log streams?](https://docs.victoriametrics.com/victorialogs/keyconcepts/#how-to-determine-which-fields-must-be-associated-with-log-streams)",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 157,
+              "i": "93690da4-c286-47bd-bd89-5463622c1f5f"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(increase(vl_streams_created_total{job=~\"$job\", instance=~\"$instance\"}[1d])) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "f81470d9-a5d1-4e30-a816-33dbab0bfab5",
+            "type": "barGauge",
+            "name": "Non-default flags（非默认启动参数）",
+            "description": "Flags explicitly set to non-default values",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 189,
+              "i": "f81470d9-a5d1-4e30-a816-33dbab0bfab5"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(flag{is_set=\"true\", job=~\"$job\", instance=~\"$instance\"}) by(instance, name, value)\nor\nlabel_replace(\n  label_replace(\n    sum(flag{is_set=\"true\", job=~\"$job\", instance=~\"$instance\"}) by(instance),\n    \"name\",  \"---------\", \"instance\", \"(.*)\"\n  ),\n  \"value\", \"---------\", \"instance\", \"(.*)\"\n)",
+                "legend": "{{name}}={{value}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "line",
+                "steps": [
+                  {
+                    "color": "transparent",
+                    "value": 0
+                  }
+                ]
+              },
+              "standardOptions": {
+                "unit": "none"
+              },
+              "legend": {
+                "displayMode": "hidden"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "calc": "lastNotNull",
+              "displayMode": "basic",
+              "orientation": "horizontal",
+              "textSize": {}
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}",
+            "overrides": [],
+            "transformationsNG": []
+          },
+          {
+            "version": "3.4.0",
+            "id": "067536b1-247c-474b-b509-2ce8c65c7ffd",
+            "type": "timeseries",
+            "name": "Logs dropped for last 1h",
+            "description": "Number of log entries ignored or dropped on insertion due to the following reasons:\n* Timestamp out of the retention period or in the future\n* Number of fields per entry exceeded\n* Line too long\n\nIf this occurs, check the VictoriaLogs log for details.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 189,
+              "i": "067536b1-247c-474b-b509-2ce8c65c7ffd"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(increase(vl_rows_dropped_total{job=~\"$job\", instance=~\"$instance\"}[1h])) by (reason) ",
+                "legend": "{{reason}}"
+              },
+              {
+                "refId": "B",
+                "expr": "sum(increase(vl_too_long_lines_skipped_total{job=~\"$job\", instance=~\"$instance\"}[1h]))",
+                "legend": "line_too_long"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none"
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          }
+        ]
+      },
+      {
+        "version": "3.4.0",
+        "id": "1c56ab3f-5ef3-4b3b-a4a5-5b3eb35919d7",
+        "type": "row",
+        "name": "Storage",
+        "collapsed": false,
+        "layout": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 101,
+          "i": "1c56ab3f-5ef3-4b3b-a4a5-5b3eb35919d7"
+        },
+        "panels": [
+          {
+            "version": "3.4.0",
+            "id": "ea444927-c2d1-4ede-834c-cfa8da759389",
+            "type": "stat",
+            "name": "Partition Count",
+            "description": "Number of daily partitions currently stored on disk.\n\nVictoriaLogs stores data in daily partitions, so this roughly matches the number of days with data kept. It increases as new days arrive and decreases when retention removes older days.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 3,
+              "x": 0,
+              "y": 102,
+              "i": "ea444927-c2d1-4ede-834c-cfa8da759389"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(vl_partitions{job=~\"$job\", instance=~\"$instance\"})",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "line",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none"
+              },
+              "legend": {
+                "displayMode": "list"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "textMode": "value",
+              "calc": "lastNotNull",
+              "colorMode": "value"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "b8754172-772f-4db6-be13-c1c5c4e57234",
+            "type": "timeseries",
+            "name": "Part count max by type ($instance)",
+            "description": "Number of storage parts (data files) in each tier. More parts mean fragmentation; fewer parts suggest successful merging. High part counts may slow queries and trigger background merge operations.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 9,
+              "x": 3,
+              "y": 102,
+              "i": "b8754172-772f-4db6-be13-c1c5c4e57234"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(vl_storage_parts{job=~\"$job\", instance=~\"$instance\"}) by(type)",
+                "legend": "{{type}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none"
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "a15f339f-af03-46dc-a6a3-b8cd67445915",
+            "type": "timeseries",
+            "name": "Disk ($instance)",
+            "description": "Disk space usage and limits for VictoriaLogs storage. Tracks current data usage against the configured retention limit and total disk space.\n\nThe orange line indicates the space retention limit. When usage approaches this limit, older data will be automatically deleted. If the space retention limit (`-retention.maxDiskSpaceUsageBytes`) is not specified, it won't show.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 102,
+              "i": "a15f339f-af03-46dc-a6a3-b8cd67445915"
+            },
+            "targets": [
+              {
+                "refId": "B",
+                "expr": "max(\n  sum(max_over_time(vl_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)\n  / on (instance)\n  vl_total_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"}\n) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "line",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 1
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "percentUnit"
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "321eaf88-8be5-4cc6-bcc1-04bb323220f8",
+            "type": "timeseries",
+            "name": "Merge events",
+            "description": "Number of storage merge operations by type (sum across instances). Merges compact smaller parts into larger ones; bursts are normal after activity spikes.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 110,
+              "i": "321eaf88-8be5-4cc6-bcc1-04bb323220f8"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(increase(vl_merges_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(type)",
+                "legend": "{{type}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "d00734c6-50e4-4101-a4d7-bff3469c26ca",
+            "type": "timeseries",
+            "name": "Merge duration p99 ($instance)",
+            "description": "99th percentile duration of merge operations by storage type. Merge operations combine smaller storage parts into larger ones for optimization. \n\nNormal merge durations vary by storage type and data volume. Consistently high durations may indicate storage performance issues, high write load, or insufficient resources for background operations. Monitor for trends that could impact overall system performance.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 110,
+              "i": "d00734c6-50e4-4101-a4d7-bff3469c26ca"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(vl_merge_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (type)",
+                "legend": "{{type}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "seconds"
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "1bf6d762-c360-47aa-8d00-2f93a22201a5",
+            "type": "timeseries",
+            "name": "Merge bytes p99 ($instance)",
+            "description": "99th percentile of data volume processed during merge operations by storage type. \n\nThis metric indicates the scale of background storage optimization activities. Larger merge sizes generally improve storage efficiency but require more resources. Consistently high values may indicate heavy write loads or large storage parts that need optimization. Monitor correlation with merge duration for performance insights.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 118,
+              "i": "1bf6d762-c360-47aa-8d00-2f93a22201a5"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(vl_merge_bytes{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (type)",
+                "legend": "{{type}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "bytesIEC",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "492d2fb2-03a5-411f-9457-86aae1502650",
+            "type": "timeseries",
+            "name": "Pending rows ($instance)",
+            "description": "Number of log rows waiting to be written to storage, categorized by type. Pending rows indicate temporary queuing during ingestion. Consistently high values may suggest storage write bottlenecks or insufficient write capacity.\n\nPending rows are flushed in two ways:\n\n- After a specific time period (typically 1 second)\n- When the pending row size exceeds a threshold (typically 1.75 MB)",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 118,
+              "i": "492d2fb2-03a5-411f-9457-86aae1502650"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(vl_pending_rows{job=~\"$job\", instance=~\"$instance\"}) by (type)",
+                "legend": "{{type}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "a6f2e0ab-fc41-4515-9f13-57bf597025f5",
+            "type": "timeseries",
+            "name": "Storage read-only ($instance)",
+            "description": "Shows whether the VictoriaLogs instance is in read-only mode.\nValue is 1 when storage is read-only (free disk space below `-storage.minFreeDiskSpaceBytes`), otherwise 0.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 126,
+              "i": "a6f2e0ab-fc41-4515-9f13-57bf597025f5"
+            },
+            "targets": [
+              {
+                "refId": "B",
+                "expr": "max(max_over_time(vl_storage_is_read_only{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "line",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none"
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          }
+        ]
+      },
+      {
+        "version": "3.4.0",
+        "id": "0fc15914-720c-45c7-bb0a-1552802ccc8a",
+        "type": "row",
+        "name": "Ingestion",
+        "collapsed": false,
+        "layout": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 102,
+          "i": "0fc15914-720c-45c7-bb0a-1552802ccc8a"
+        },
+        "panels": [
+          {
+            "version": "3.4.0",
+            "id": "95e28194-6f9f-484b-a7eb-428009f33d3a",
+            "type": "timeseries",
+            "name": "Logs ingestion rate",
+            "description": "How fast logs are coming in.\n\nThis shows the ingestion rate, split by source type (for example: Loki, Elasticsearch, syslog). You'll see both:\n- events per second\n- estimated data volume per second\n\nIf this suddenly spikes, expect higher CPU and disk usage. If it drops to near zero, check upstream shippers/agents and this cluster's insert health.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 625,
+              "i": "95e28194-6f9f-484b-a7eb-428009f33d3a"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type)",
+                "legend": "{{type}}"
+              },
+              {
+                "refId": "B",
+                "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) ",
+                "legend": "{{type}} (bytes)"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "6dc6d1f1-4c44-46d5-9414-7842d5591e89",
+            "type": "timeseries",
+            "name": "Request rate",
+            "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 625,
+              "i": "6dc6d1f1-4c44-46d5-9414-7842d5591e89"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\",path=~\"^/(internal/)?insert.*\"}[$__rate_interval])) by (path)",
+                "legend": "{{path}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "62aa59d2-1b81-4a4b-a83e-126639dd76e9",
+            "type": "timeseries",
+            "name": "Insert duration p99",
+            "description": "99th percentile of insert operation duration. This represents the time it takes for 99% of insert operations to complete. High values indicate slow ingestion performance that could affect overall system throughput. Spikes may suggest storage bottlenecks, resource contention, or inefficient data processing.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 633,
+              "i": "62aa59d2-1b81-4a4b-a83e-126639dd76e9"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\", path=~\"^/(internal/)?insert.*\"}) by (path)",
+                "legend": "{{path}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "seconds",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "89b69219-2682-41b6-aa3e-da9e5facef77",
+            "type": "timeseries",
+            "name": "Request duration p99 ($instance)",
+            "description": "99th percentile response time for VictoriaLogs HTTP endpoints, grouped by instance and path. This means 99% of requests are faster than this value. **Lower numbers are better**, as they indicate faster responses and fewer slow requests.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 633,
+              "i": "89b69219-2682-41b6-aa3e-da9e5facef77"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\", path=~\"^/(internal/)?insert.*\"}) by (path)",
+                "legend": "{{path}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "seconds",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "c40c1b7d-889d-417d-bf24-d3cf37af870f",
+            "type": "timeseries",
+            "name": "Message processors ($instance)",
+            "description": "Number of active message processors handling log ingestion. These processors parse and process incoming log messages before storage.\n\nThe `soft limit` line is the configured concurrency limit for insert request processing (`-maxConcurrentInserts`). It is marked as soft because streaming/slow clients may keep many HTTP requests in-flight while only a limited number of them are actively processed at the same time.\n\nIf processors are consistently high, correlate with ingestion rate and memory/CPU usage. Sudden growth may indicate burst traffic, slow clients/network, or backpressure from storage nodes.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 641,
+              "i": "c40c1b7d-889d-417d-bf24-d3cf37af870f"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(max_over_time(vl_insert_processors_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+                "legend": "{{instance}}"
+              },
+              {
+                "refId": "B",
+                "expr": "max(max_over_time(vm_concurrent_insert_capacity{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+                "legend": "soft limit"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "min": 0,
+                "decimals": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "957c5489-1d5f-4727-8504-df2754316a41",
+            "type": "timeseries",
+            "name": "Max pending rows ($instance)",
+            "description": "Number of log rows waiting to be written to storage, categorized by type. Pending rows indicate temporary queuing during ingestion. Consistently high values may suggest storage write bottlenecks or insufficient write capacity.\n\nPending rows are flushed in two ways:\n\n- After a specific time period (typically 1 second)\n- When the pending row size exceeds a threshold (typically 1.75 MB)",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 641,
+              "i": "957c5489-1d5f-4727-8504-df2754316a41"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(vl_pending_rows{job=~\"$job\", instance=~\"$instance\"}) by (type)",
+                "legend": "{{type}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "78e6e929-f292-4a82-a627-187eb30561fe",
+            "type": "timeseries",
+            "name": "Concurrent insert limit reached ($instance)",
+            "description": "Insert requests that hit the ingestion concurrency limit and had to wait in a queue (per time interval).\n\nVictoriaLogs limits the number of concurrent insert requests with `-maxConcurrentInserts`. This protects the server from too many simultaneous in-flight inserts.\n\nIf this is frequently above zero, ingestion is under pressure. A common reason is slow client networks (requests take longer, so they occupy concurrency slots longer). In that case, increasing `-maxConcurrentInserts` can help if the server still has CPU headroom. If CPU is already saturated, prefer scaling out insert nodes and/or reducing client-side parallelism/batch size instead.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 649,
+              "i": "78e6e929-f292-4a82-a627-187eb30561fe"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(increase(vm_concurrent_insert_limit_reached_total[$__rate_interval])) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "08e5ba52-fe5a-42d7-b5fb-fffc8d3962f9",
+            "type": "timeseries",
+            "name": "Insert timeouts ($instance)",
+            "description": "Number of insert requests that timed out while waiting for available concurrency slots. This indicates sustained ingestion overload beyond configured limits.\n\nHigh values suggest:\n- Insert queue is consistently full\n- Insert requests waiting too long for execution slots\n- System under sustained heavy ingestion load\n- Need for horizontal scaling or ingestion optimization\n\nCombined with `Insert concurrency limit reached`, provides complete picture of ingestion rejection patterns.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 649,
+              "i": "08e5ba52-fe5a-42d7-b5fb-fffc8d3962f9"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(rate(vm_concurrent_insert_limit_timeout_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 1
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none"
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "beb873e0-b611-4fa5-9972-e11ad309e5ad",
+            "type": "timeseries",
+            "name": "Flush duration p99",
+            "description": "99th percentile duration of background flush operations by type. High values may indicate disk pressure or heavy ingestion. Correlate with `I/O` panels.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 657,
+              "i": "beb873e0-b611-4fa5-9972-e11ad309e5ad"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(vl_insert_flush_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (type)",
+                "legend": "{{type}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "seconds",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          }
+        ]
+      },
+      {
+        "version": "3.4.0",
+        "id": "fb40541c-64a5-4731-a8bf-b798ba264088",
+        "type": "row",
+        "name": "Querying",
+        "collapsed": false,
+        "layout": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 103,
+          "i": "fb40541c-64a5-4731-a8bf-b798ba264088"
+        },
+        "panels": [
+          {
+            "version": "3.4.0",
+            "id": "d44a8fdb-2def-44d2-a472-7bc07be6b8d0",
+            "type": "timeseries",
+            "name": "Query rate",
+            "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 859,
+              "i": "d44a8fdb-2def-44d2-a472-7bc07be6b8d0"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\",path=~\"^/(internal/)?select.*\"}[$__rate_interval])) by (path)",
+                "legend": "{{path}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "c5888d5d-fa85-4079-86d2-10474641f7ae",
+            "type": "timeseries",
+            "name": "Query duration p99",
+            "description": "99th percentile of query execution duration. This represents the time it takes for 99% of queries to complete:\n\n- High values indicate slow query performance that affects user experience. \n- Spikes may suggest complex queries, resource contention, or inefficient indexes. Monitor for trends that could indicate degrading performance.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 859,
+              "i": "c5888d5d-fa85-4079-86d2-10474641f7ae"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\", path=~\"^/(internal/)?select.*\"}) by (path)",
+                "legend": "{{path}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "seconds",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "475f0ba3-6b79-4704-bd2d-9f5d2fb3a7f4",
+            "type": "timeseries",
+            "name": "Concurrent queries ($instance)",
+            "description": "Number of concurrent select (query) operations compared to the configured limit.\n\nHigh utilization near the limit may indicate query bottlenecks or insufficient query processing capacity.\n\nIf it's consistently high while CPU usage remains low, consider increasing the concurrency limit (`-search.maxConcurrentRequests`) or optimizing query performance to support more concurrent users.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 899,
+              "i": "475f0ba3-6b79-4704-bd2d-9f5d2fb3a7f4"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(max_over_time(vl_concurrent_select_current{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+                "legend": "{{instance}}"
+              },
+              {
+                "refId": "B",
+                "expr": "max(max_over_time(vl_concurrent_select_capacity{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+                "legend": "limit"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "desc"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "55e81383-cc3f-4532-8ab4-82173386f1a1",
+            "type": "timeseries",
+            "name": "Query timeouts ($instance)",
+            "description": "Number of queries that timed out while waiting for available concurrency slots. This indicates sustained query overload beyond configured limits.\n\nHigh values suggest:\n- Query queue is consistently full\n- Queries waiting too long for execution slots\n- System under sustained heavy load\n- Need for horizontal scaling or query optimization\n\nCombined with `Select concurrency limit reached`, provides complete picture of query rejection patterns.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 899,
+              "i": "55e81383-cc3f-4532-8ab4-82173386f1a1"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum(rate(vl_concurrent_select_limit_timeout_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 1
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none"
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          }
+        ]
+      },
+      {
+        "version": "3.4.0",
+        "id": "136b0b34-d188-4107-acbb-f87f57d37556",
+        "type": "row",
+        "name": "Slow Query Troubleshooting",
+        "collapsed": false,
+        "layout": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 104,
+          "i": "136b0b34-d188-4107-acbb-f87f57d37556"
+        },
+        "panels": [
+          {
+            "version": "3.4.0",
+            "id": "b256ec52-67bd-4cd0-a034-b0b79c0abc97",
+            "type": "timeseries",
+            "name": "Blocks/query p99 ($instance)",
+            "description": "Number of storage blocks scanned per query (99th percentile). Each block contains logs for a single log stream over some time range.\n\nHigh values usually mean the query has to consider many blocks, for example because:\n- The time range is wide\n- The query doesn’t narrow down log streams (e.g. no good stream filter)\n- The filters are not selective and cannot quickly skip blocks\n\nCorrelate with `Bytes/query p99`: if blocks are high but bytes are low, each block contributes little data (often OK). If both are high, the query is reading a lot of data from storage.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 860,
+              "i": "b256ec52-67bd-4cd0-a034-b0b79c0abc97"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_processed_blocks_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "none",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "c8ce22e2-4ac3-4f74-81a7-c35d6ecf115c",
+            "type": "timeseries",
+            "name": "Bytes/query p99 ($instance)",
+            "description": "Total bytes read from disk per query (99th percentile). This represents the complete `I/O` overhead for query execution, including:\n\n- Block headers and metadata\n- Bloom filter data for candidate selection\n- Column headers and indexes\n- Actual log values and timestamps\n\nHigh values indicate expensive queries. Compare with specific breakdown panels below to identify bottlenecks. Monitor trends over time and correlate with query complexity.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 860,
+              "i": "c8ce22e2-4ac3-4f74-81a7-c35d6ecf115c"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_total_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "bytesIEC",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "9764dc48-c927-48c3-b04e-83ebceb36183",
+            "type": "timeseries",
+            "name": "Block header bytes/query p99 ($instance)",
+            "description": "Bytes read from block headers per query (99th percentile). Block headers contain metadata about each storage block including `time ranges`, `field names`, and data location pointers.\n\nHigh values indicate:\n- Query `time range` spans many blocks (reduce time range or add time-based filters)\n- Missing stream-level filters (`_stream` field) causing full block header scans\n- High cardinality fields creating excessive blocks\n\nMonitor relative changes over time - sudden increases suggest inefficient query patterns or changes in data structure.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 868,
+              "i": "9764dc48-c927-48c3-b04e-83ebceb36183"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_block_headers_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance) > 0.001",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "bytesIEC",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "c34d1c25-d1c5-4442-80bd-10a00f8788f4",
+            "type": "timeseries",
+            "name": "Bloom filter bytes/query p99 ($instance)",
+            "description": "Bytes read from Bloom filters per query (99th percentile). `Bloom filters` are probabilistic data structures that quickly eliminate blocks that definitely don't contain search terms.\n\nHigh values indicate:\n- Queries with low-selectivity text filters (common words like `error`, `info`)\n- Missing or ineffective field-based filters\n- Queries that force scanning many candidate blocks\n\nOptimize by adding specific field filters (`kubernetes.container_name`, `_stream`) before text searches. Monitor for sudden increases that indicate poor filter selectivity.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 868,
+              "i": "c34d1c25-d1c5-4442-80bd-10a00f8788f4"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_bloom_filters_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance) > 0.001",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "bytesIEC",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "b9e2e4e9-299f-4afb-b981-17a99a883030",
+            "type": "timeseries",
+            "name": "Value bytes/query p99 ($instance)",
+            "description": "Bytes read from log values per query (99th percentile). This measures storage I/O spent on reading field values (not metadata like headers/bloom filters).\n\nHigh values indicate queries that have to fetch lots of log content from disk, for example because:\n- The time range is wide or filters are not selective\n- The query matches many logs\n- Logs have large payloads (large messages / JSON blobs / stack traces)\n\nIf you want to understand how much data was processed after decompression/decoding (CPU work), compare with the corresponding “uncompressed values processed bytes” metric/panel.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 876,
+              "i": "b9e2e4e9-299f-4afb-b981-17a99a883030"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_values_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "bytesIEC",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "d33f314c-c2ad-48cb-b174-de61615dc792",
+            "type": "timeseries",
+            "name": "_time bytes/query p99 ($instance)",
+            "description": "Bytes read from the `_time` field per query (99th percentile). The `_time` field is used to narrow queries to the selected time range.\n\nHigh values usually mean the query spans a wide time range and/or touches many blocks, so more timestamp data needs to be read.\n\nThis is typically a smaller part of total query I/O compared to reading log values, so correlate with `Bytes/query p99` and `Value bytes/query p99` when investigating slow queries.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 876,
+              "i": "d33f314c-c2ad-48cb-b174-de61615dc792"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_timestamps_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "bytesIEC",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "8a373701-048e-45d1-ac34-2610738d7a1a",
+            "type": "timeseries",
+            "name": "Column header index bytes/query p99 ($instance)",
+            "description": "Bytes read from column header indexes per query (99th percentile). `Column header indexes` contain metadata about which fields exist in each block and their data types.\n\nHigh values suggest:\n- Queries scanning many blocks due to missing field filters\n- High field cardinality creating large index structures\n- Queries accessing many different field names across blocks\n- Schema evolution causing index fragmentation\n\nOptimize by using consistent `field names` and adding field-specific filters early in query pipeline.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 884,
+              "i": "8a373701-048e-45d1-ac34-2610738d7a1a"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_columns_header_indexes_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "bytesIEC",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          },
+          {
+            "version": "3.4.0",
+            "id": "1488c275-1d3d-4c87-b564-6b102c819b8b",
+            "type": "timeseries",
+            "name": "Column header bytes/query p99 ($instance)",
+            "description": "Bytes read from column headers per query (99th percentile). `Column headers` store the actual field schema and compression metadata for each block's columns.\n\nThis metric helps identify:\n- Schema complexity overhead (many fields per log entry)\n- Inefficient field access patterns\n- Blocks with heterogeneous schemas requiring header reads\n\nCompare with other `I/O` breakdown panels to understand query cost distribution. High column header reads suggest schema optimization opportunities or need for more selective field access patterns.",
+            "links": [],
+            "layout": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 884,
+              "i": "1488c275-1d3d-4c87-b564-6b102c819b8b"
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "max(histogram_quantile(0.99, sum(increase(vl_storage_per_query_columns_headers_read_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))) by (instance)",
+                "legend": "{{instance}}"
+              }
+            ],
+            "options": {
+              "valueMappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "style": "off",
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 80
+                  }
+                ]
+              },
+              "standardOptions": {
+                "util": "bytesIEC",
+                "min": 0
+              },
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "all",
+                "sort": "none"
+              }
+            },
+            "custom": {
+              "version": "3.4.0",
+              "drawStyle": "lines",
+              "lineInterpolation": "linear",
+              "fillOpacity": 0,
+              "stack": "off"
+            },
+            "maxPerRow": 4,
+            "datasourceCate": "prometheus",
+            "datasourceValue": "${DS_PROMETHEUS}"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/automq-log-buffer-runbook.md
+++ b/docs/automq-log-buffer-runbook.md
@@ -137,14 +137,20 @@ Kafka/Vector错误和 OBS 4xx/5xx为零。
 ## 6. 监控
 
 AutoMQ Prometheus监听容器内 `8890`，宿主机仅绑定 loopback。两个 consumer 分别暴露
-`9598`/`9599`，CCE producer 使用同样的 hostPort。固定版 vmagent 抓取这些端点和
-本机 node-exporter，remote write到现有 VictoriaMetrics。
+`9598`/`9599`，CCE producer 使用同样的 hostPort。固定版 vmagent 抓取这些端点、
+本机 node-exporter、VictoriaLogs `/metrics` 和 vmagent 自身，再 remote write到现有
+VictoriaMetrics。VictoriaLogs target通过 `VICTORIALOGS_METRICS_TARGET=host:port` 渲染，
+不得把真实内网地址写回仓库模板。
 
 导入 `monitoring/grafana/automq-cluster.json` 到现有监控 Grafana，datasource变量绑定
-现有 VictoriaMetrics；将原生夜莺大屏和 `monitoring/alert-rules.yml` 一起导入金龄云
-SaaS 业务组，不得放入通用基础设施或其他项目业务组。至少验证 Broker down、
-Controller、S3 request error、Kafka request error、consumer lag、producer queue、
-可用内存和 CPU告警均可产生并恢复。
+现有 VictoriaMetrics；夜莺使用
+`monitoring/nightingale/automq-cluster.json` 原生增强版，避免官方 Grafana模板的空标题
+和表格转换丢失。VictoriaLogs 使用随精确版本发布的官方单机大屏
+`docker-compose/victorialogs/monitoring/grafana/victorialogs-v1.52.0.json`。三个资产和
+`monitoring/alert-rules.yml` 一起归属金龄云 SaaS业务组，不得放入通用基础设施或其他
+项目业务组。至少验证 Broker down、Controller、S3 request error、Kafka request
+error、consumer lag、producer queue、VictoriaLogs写入/查询/丢弃/磁盘、可用内存和
+CPU告警均可产生并恢复。
 
 ## 7. 回滚
 

--- a/scripts/render-automq-nightingale-dashboard.mjs
+++ b/scripts/render-automq-nightingale-dashboard.mjs
@@ -5,71 +5,119 @@ const root = resolve(import.meta.dirname, "..");
 const output = resolve(root, "docker-compose/automq/monitoring/nightingale/automq-cluster.json");
 const datasource = { cate: "prometheus", value: "${datasource}" };
 
-const thresholds = (warning = null) => ({
+const thresholdSteps = (warning = null, critical = null) => ({
   mode: "absolute",
   style: "line",
   steps: [
     { color: "#73BF69", value: null, type: "base" },
-    ...(warning === null ? [] : [{ color: "#F2495C", value: warning }]),
+    ...(warning === null ? [] : [{ color: "#FADE2A", value: warning }]),
+    ...(critical === null ? [] : [{ color: "#F2495C", value: critical }]),
   ],
 });
 
-const options = (unit = "none", warning = null) => ({
+const options = (unit = "none", warning = null, critical = null) => ({
   valueMappings: [],
-  thresholds: thresholds(warning),
-  standardOptions: { util: unit },
-  legend: { displayMode: "list", placement: "bottom" },
+  thresholds: thresholdSteps(warning, critical),
+  standardOptions: { unit },
+  legend: { displayMode: "table", placement: "bottom" },
   tooltip: { mode: "all", sort: "desc" },
 });
 
-const target = (refId, expr, legend) => ({ refId, expr, legend });
+const target = (refId, expr, legend, instant = false) => ({ refId, expr, legend, instant });
 
-const panel = (id, type, name, layout, targets, unit = "none", warning = null) => ({
+const panel = (id, type, name, description, layout, targets, unit = "none", warning = null, critical = null) => ({
   version: "3.4.0",
   id,
   type,
   name,
+  description,
   links: [],
   layout: { ...layout, i: id },
   targets,
-  options: options(unit, warning),
+  options: options(unit, warning, critical),
   custom: type === "stat"
-    ? { version: "3.4.0", textMode: "value", calc: "lastNotNull", colorMode: "value" }
+    ? { version: "3.4.0", textMode: "valueAndName", calc: "lastNotNull", colorMode: "value", textSize: {} }
     : type === "barGauge"
-      ? { version: "3.4.0", calc: "lastNotNull" }
+      ? { version: "3.4.0", calc: "lastNotNull", displayMode: "basic", orientation: "horizontal", textSize: {} }
       : {
           version: "3.4.0",
           drawStyle: "lines",
           lineInterpolation: "linear",
-          fillOpacity: 0.2,
+          lineWidth: 2,
+          fillOpacity: 0.18,
+          gradientMode: "none",
+          showPoints: "never",
+          scaleDistribution: { type: "linear" },
           stack: "off",
         },
+  overrides: [],
+  transformationsNG: [],
   maxPerRow: 4,
   datasourceCate: "prometheus",
   datasourceValue: "${datasource}",
 });
 
-const stat = (id, name, layout, expr, legend, unit = "none", warning = null) =>
-  panel(id, "stat", name, layout, [target("A", expr, legend)], unit, warning);
-const timeseries = (id, name, layout, targets, unit = "none") =>
-  panel(id, "timeseries", name, layout, targets, unit);
-const barGauge = (id, name, layout, targets) =>
-  panel(id, "barGauge", name, layout, targets);
+const row = (id, name, y) => ({
+  version: "3.4.0",
+  id,
+  type: "row",
+  name,
+  collapsed: true,
+  layout: { h: 1, w: 24, x: 0, y, i: id, isResizable: false },
+  targets: [],
+  options: {},
+  custom: {},
+  overrides: [],
+  transformationsNG: [],
+});
+
+const stat = (id, name, description, layout, expr, legend, unit = "none", warning = null, critical = null) =>
+  panel(id, "stat", name, description, layout, [target("A", expr, legend, true)], unit, warning, critical);
+const availabilityStat = (id, name, description, layout, expr, legend) => {
+  const result = stat(id, name, description, layout, expr, legend);
+  result.options.thresholds.steps = [
+    { color: "#F2495C", value: null, type: "base" },
+    { color: "#73BF69", value: 1 },
+  ];
+  return result;
+};
+const timeseries = (id, name, description, layout, targets, unit = "none", warning = null, critical = null) =>
+  panel(id, "timeseries", name, description, layout, targets, unit, warning, critical);
+const barGauge = (id, name, description, layout, targets, unit = "none") =>
+  panel(id, "barGauge", name, description, layout, targets, unit);
 
 const dashboard = {
-  name: "AutoMQ Logs - Production",
-  tags: "automq production logs",
-  note: "AutoMQ log buffer health, throughput, lag and recovery signals.",
+  name: "AutoMQ 生产集群监控（官方指标增强版）",
+  tags: "automq production kafka victorialogs vector",
+  note: "基于 AutoMQ 1.7.4 官方 Cluster Overview 与 Prometheus 指标语义，补齐夜莺原生标题、说明、Broker/请求/KRaft/JVM/S3/WAL/Vector 链路监控。单节点部署不是高可用架构。",
   ident: "automq-production-cluster",
   uuid: 1788455364871001,
   configs: {
     version: "3.4.0",
-    links: [],
+    links: [
+      {
+        title: "AutoMQ 1.7.4 官方监控源",
+        url: "https://github.com/AutoMQ/automq/blob/1.7.4/docker/telemetry/grafana/provisioning/dashboards/User/cluster.json",
+        targetBlank: true,
+      },
+      {
+        title: "AutoMQ 指标说明",
+        url: "https://docs.automq.com/automq/observability/metrics",
+        targetBlank: true,
+      },
+    ],
     var: [
+      {
+        type: "datasource",
+        name: "datasource",
+        label: "数据源",
+        definition: "prometheus",
+        hide: false,
+      },
       {
         type: "query",
         name: "cluster_id",
-        label: "Cluster",
+        label: "AutoMQ 集群",
         allOption: false,
         multi: false,
         reg: "",
@@ -77,58 +125,135 @@ const dashboard = {
         definition: "label_values(kafka_broker_active_count,job)",
         datasource,
       },
-      {
-        type: "datasource",
-        name: "datasource",
-        label: "Data Source",
-        definition: "prometheus",
-        hide: false,
-      },
     ],
     panels: [
-      stat("automq-controller", "Active Controller", { h: 6, w: 4, x: 0, y: 0 },
-        'sum(kafka_controller_active_count{job="$cluster_id"})', "controller"),
-      stat("automq-broker", "Active Broker", { h: 6, w: 4, x: 4, y: 0 },
-        'sum(kafka_broker_active_count{job="$cluster_id"})', "broker"),
-      stat("automq-fenced", "Fenced Broker", { h: 6, w: 4, x: 8, y: 0 },
-        'sum(kafka_broker_fenced_count{job="$cluster_id"}) or vector(0)', "fenced", "none", 1),
-      stat("automq-topics", "Topics", { h: 6, w: 4, x: 12, y: 0 },
-        'sum(kafka_topic_count{job="$cluster_id"})', "topics"),
-      stat("automq-partitions", "Partitions", { h: 6, w: 4, x: 16, y: 0 },
-        'sum(kafka_partition_total_count{job="$cluster_id"})', "partitions"),
-      stat("automq-size", "Stored Log Bytes", { h: 6, w: 4, x: 20, y: 0 },
-        'sum(max by(topic,partition) (kafka_log_size{job="$cluster_id"}))', "bytes", "bytesIEC"),
-      timeseries("automq-network", "Broker Bytes In / Out", { h: 10, w: 12, x: 0, y: 6 }, [
-        target("A", 'sum(rate(kafka_broker_network_io_bytes_total{job="$cluster_id",direction="in"}[$__rate_interval]))', "in"),
-        target("B", 'sum(rate(kafka_broker_network_io_bytes_total{job="$cluster_id",direction="out"}[$__rate_interval]))', "out"),
-      ], "bytesSIps"),
-      timeseries("automq-requests", "Produce / Fetch Requests", { h: 10, w: 12, x: 12, y: 6 }, [
-        target("A", 'sum(rate(kafka_request_count_total{job="$cluster_id",type="Produce"}[$__rate_interval]))', "produce"),
-        target("B", 'sum(rate(kafka_request_count_total{job="$cluster_id",type="Fetch"}[$__rate_interval]))', "fetch"),
-        target("C", 'sum(rate(kafka_request_error_count_total{job="$cluster_id",error!="NONE"}[$__rate_interval])) or vector(0)', "errors"),
-      ], "reqps"),
-      timeseries("automq-latency", "Kafka Request P99", { h: 10, w: 12, x: 0, y: 16 }, [
-        target("A", 'max(kafka_request_time_99p_milliseconds{job="$cluster_id",type="Produce"})', "produce"),
-        target("B", 'max(kafka_request_time_99p_milliseconds{job="$cluster_id",type="Fetch"})', "fetch"),
-      ], "ms"),
-      timeseries("automq-topic-rate", "Topic Message Rate", { h: 10, w: 12, x: 12, y: 16 }, [
-        target("A", 'sum by(topic) (rate(kafka_message_count_total{job="$cluster_id",direction="in"}[$__rate_interval]))', "{{topic}} in"),
+      row("row-health", "一、集群健康与容量", 0),
+      availabilityStat("automq-controller", "活动 Controller", "KRaft 当前活动 Controller 数量。单节点基线应为 1；为 0 时集群无法完成控制面操作。", { h: 5, w: 3, x: 0, y: 1 }, 'sum(kafka_controller_active_count{job="$cluster_id"})', "Controller"),
+      availabilityStat("automq-broker", "活动 Broker", "当前可提供 Kafka 读写服务的 Broker 数量。现网单节点基线应为 1。", { h: 5, w: 3, x: 3, y: 1 }, 'sum(kafka_broker_active_count{job="$cluster_id"})', "Broker"),
+      stat("automq-fenced", "被隔离 Broker", "被 Controller 隔离、不能承担读写的 Broker 数量。正常值为 0。", { h: 5, w: 3, x: 6, y: 1 }, 'sum(kafka_broker_fenced_count{job="$cluster_id"}) or vector(0)', "Fenced", "none", null, 1),
+      stat("automq-offline", "离线分区", "没有可用 Leader 的分区数量。正常值为 0；大于 0 会直接影响生产或消费。", { h: 5, w: 3, x: 9, y: 1 }, 'sum(kafka_partition_offline_count{job="$cluster_id"}) or vector(0)', "Offline", "none", null, 1),
+      stat("automq-topics", "Topic 数", "AutoMQ 中当前 Topic 总数，包含系统内部 Topic。", { h: 5, w: 3, x: 12, y: 1 }, 'max(kafka_topic_count{job="$cluster_id"})', "Topics"),
+      stat("automq-partitions", "分区总数", "所有 Topic 的分区总数。现网业务 Topic 之外还包含 Kafka/AutoMQ 系统分区。", { h: 5, w: 3, x: 15, y: 1 }, 'max(kafka_partition_total_count{job="$cluster_id"})', "Partitions"),
+      stat("automq-size", "逻辑日志量", "按 Topic/Partition 去重后的 Kafka 逻辑日志大小，不等于 OBS 实际计费容量。", { h: 5, w: 3, x: 18, y: 1 }, 'sum(max by(topic,partition) (kafka_log_size{job="$cluster_id"}))', "Stored", "bytesIEC"),
+      stat("automq-errors", "错误请求/秒", "Kafka 非 NONE 错误响应速率。短时认证探测可能产生少量错误，持续增长必须按 error 标签定位。", { h: 5, w: 3, x: 21, y: 1 }, 'sum(rate(kafka_request_error_count_total{job="$cluster_id",error!="NONE"}[$__rate_interval])) or vector(0)', "Errors/s", "reqps", 0.01, 1),
+
+      row("row-traffic", "二、流量、请求与 Broker 压力", 6),
+      timeseries("automq-network", "Broker 网络吞吐", "Broker 接收与发送字节速率；入站主要是 producer，出站主要是 consumer。", { h: 9, w: 12, x: 0, y: 7 }, [
+        target("A", 'sum(rate(kafka_broker_network_io_bytes_total{job="$cluster_id",direction="in"}[$__rate_interval]))', "写入"),
+        target("B", 'sum(rate(kafka_broker_network_io_bytes_total{job="$cluster_id",direction="out"}[$__rate_interval]))', "读取"),
+      ], "bytesSecIEC"),
+      timeseries("automq-topic-rate", "各 Topic 消息写入速率", "按 Topic 展示进入 Broker 的消息速率，用于识别 VVG 与 Gateway 流量变化。", { h: 9, w: 12, x: 12, y: 7 }, [
+        target("A", 'sum by(topic) (rate(kafka_message_count_total{job="$cluster_id",direction="in"}[$__rate_interval]))', "{{topic}}"),
       ], "mps"),
-      timeseries("automq-consumer-lag", "Vector Consumer Lag", { h: 10, w: 12, x: 0, y: 26 }, [
+      timeseries("automq-requests", "Produce / Fetch 请求速率", "Broker 每秒处理的生产与拉取请求。请求数和消息数不同，一个请求可包含多个消息。", { h: 9, w: 8, x: 0, y: 16 }, [
+        target("A", 'sum(rate(kafka_request_count_total{job="$cluster_id",type="Produce"}[$__rate_interval]))', "Produce"),
+        target("B", 'sum(rate(kafka_request_count_total{job="$cluster_id",type="Fetch"}[$__rate_interval]))', "Fetch"),
+      ], "reqps"),
+      timeseries("automq-latency", "Kafka 请求 P99 延迟", "Produce/Fetch 请求端到端处理时间的第 99 百分位；持续升高时结合队列、线程空闲率和 S3 延迟判断。", { h: 9, w: 8, x: 8, y: 16 }, [
+        target("A", 'max(kafka_request_time_99p_milliseconds{job="$cluster_id",type="Produce"})', "Produce P99"),
+        target("B", 'max(kafka_request_time_99p_milliseconds{job="$cluster_id",type="Fetch"})', "Fetch P99"),
+      ], "ms"),
+      timeseries("automq-request-errors", "Kafka 错误响应明细", "按 Kafka error 标签拆分非成功响应，便于区分认证、Leader、超时和消息过大等错误。", { h: 9, w: 8, x: 16, y: 16 }, [
+        target("A", 'sum by(error,type) (rate(kafka_request_error_count_total{job="$cluster_id",error!="NONE"}[$__rate_interval]))', "{{type}} / {{error}}"),
+      ], "reqps"),
+      timeseries("automq-queues", "请求与响应队列", "Broker 网络线程与 I/O 线程之间的等待队列。持续堆积通常表示线程或下游存储处理不及。", { h: 9, w: 8, x: 0, y: 25 }, [
+        target("A", 'max by(type) (kafka_request_queue_size{job="$cluster_id"})', "请求 {{type}}"),
+        target("B", 'max by(type) (kafka_response_queue_size{job="$cluster_id"})', "响应 {{type}}"),
+      ]),
+      timeseries("automq-purgatory", "延迟请求等待数", "等待副本确认或数据可用的 Produce/Fetch 请求数量。持续上升要检查 Broker、Leader 与对象存储。", { h: 9, w: 8, x: 8, y: 25 }, [
+        target("A", 'sum by(type) (kafka_purgatory_size{job="$cluster_id"})', "{{type}}"),
+      ]),
+      timeseries("automq-thread-idle", "网络 / I/O 线程空闲率", "线程空闲率越低表示 Broker 越忙。长期接近 0 时请求延迟和队列通常会同步升高。", { h: 9, w: 8, x: 16, y: 25 }, [
+        target("A", 'min(kafka_network_threads_idle_rate{job="$cluster_id"})', "Network"),
+        target("B", 'min(kafka_io_threads_idle_rate_1m{job="$cluster_id"})', "I/O"),
+      ], "percentUnit"),
+
+      row("row-delivery", "三、生产者、消费者与积压", 34),
+      timeseries("automq-consumer-lag", "Vector Consumer Lag", "Kafka 最新 offset 与 Vector consumer 已提交 offset 的差值。正式 VVG/Gateway 组应在流量稳定后回落到低位。", { h: 10, w: 12, x: 0, y: 35 }, [
         target("A", 'sum by(consumer_group,topic) (clamp_min(vector_kafka_consumer_lag{partition_id!="-1"},0))', "{{consumer_group}} / {{topic}}"),
       ]),
-      timeseries("automq-producer-buffer", "Vector Producer Disk Buffer", { h: 10, w: 12, x: 12, y: 26 }, [
+      timeseries("automq-producer-buffer", "Vector Producer 磁盘缓冲", "CCE producer 尚未可靠写入 AutoMQ 的本地磁盘队列。Broker 故障时会增长，恢复后必须持续下降。", { h: 10, w: 12, x: 12, y: 35 }, [
         target("A", 'sum by(component_id,host) (vector_buffer_size_bytes{component_type="kafka",component_id=~"automq(_lane_[ab])?"})', "{{host}} / {{component_id}}"),
       ], "bytesIEC"),
-      barGauge("automq-groups", "Consumer Group State", { h: 9, w: 12, x: 0, y: 36 }, [
-        target("A", 'sum(kafka_group_count{job="$cluster_id"})', "total"),
-        target("B", 'sum(kafka_group_stable_count{job="$cluster_id"})', "stable"),
-        target("C", 'sum(kafka_group_empty_count{job="$cluster_id"})', "empty"),
-        target("D", 'sum(kafka_group_dead_count{job="$cluster_id"})', "dead"),
+      barGauge("automq-groups", "Consumer Group 状态", "stable 为正常工作组；preparing/completing_rebalance 持续非零表示频繁再均衡；empty/dead 多为历史组。", { h: 9, w: 8, x: 0, y: 45 }, [
+        target("A", 'sum(kafka_group_count{job="$cluster_id"})', "总数", true),
+        target("B", 'sum(kafka_group_stable_count{job="$cluster_id"})', "稳定", true),
+        target("C", 'sum(kafka_group_preparing_rebalance_count{job="$cluster_id"})', "准备再均衡", true),
+        target("D", 'sum(kafka_group_completing_rebalance_count{job="$cluster_id"})', "完成再均衡", true),
+        target("E", 'sum(kafka_group_empty_count{job="$cluster_id"})', "空组", true),
+        target("F", 'sum(kafka_group_dead_count{job="$cluster_id"})', "已删除", true),
       ]),
-      timeseries("automq-s3", "Object Storage Operations", { h: 9, w: 12, x: 12, y: 36 }, [
-        target("A", 'sum by(operation_name,status) (rate(kafka_stream_operation_latency_count{operation_type="S3Request"}[$__rate_interval]))', "{{operation_name}} / {{status}}"),
+      timeseries("automq-vector-throughput", "Vector Kafka 收发事件速率", "各 producer/consumer Kafka 组件接收与发送事件速率，用来定位积压发生在入 Kafka 还是出 Kafka。", { h: 9, w: 8, x: 8, y: 45 }, [
+        target("A", 'sum by(host,component_id) (rate(vector_component_received_events_total{component_type="kafka"}[$__rate_interval]))', "收到 {{host}} / {{component_id}}"),
+        target("B", 'sum by(host,component_id) (rate(vector_component_sent_events_total{component_type="kafka"}[$__rate_interval]))', "发出 {{host}} / {{component_id}}"),
+      ], "mps"),
+      timeseries("automq-vector-errors", "Vector 交付错误与丢弃", "Vector 组件错误和主动丢弃事件速率。生产链路持续非零必须结合 component_id 与 error_type 排查。", { h: 9, w: 8, x: 16, y: 45 }, [
+        target("A", 'sum by(host,component_id,error_type) (rate(vector_component_errors_total[$__rate_interval]))', "错误 {{host}} / {{component_id}} / {{error_type}}"),
+        target("B", 'sum by(host,component_id) (rate(vector_component_discarded_events_total[$__rate_interval]))', "丢弃 {{host}} / {{component_id}}"),
+      ], "mps"),
+
+      row("row-storage", "四、S3 / OBS、WAL 与缓存", 54),
+      timeseries("automq-s3-ops", "对象存储请求速率", "AutoMQ 到对象存储的 S3Request 操作速率，按操作名和状态拆分。非成功状态持续出现需要检查 OBS 网络、权限与限流。", { h: 9, w: 12, x: 0, y: 55 }, [
+        target("A", 'sum by(operation_name,status) (rate(kafka_stream_operation_latency_count{job="$cluster_id",operation_type="S3Request"}[$__rate_interval]))', "{{operation_name}} / {{status}}"),
       ], "reqps"),
+      timeseries("automq-s3-latency", "对象存储操作 P99 延迟", "S3Request 操作第 99 百分位延迟。延迟升高会传导到 WAL 上传、冷读和 Kafka 请求尾延迟。", { h: 9, w: 12, x: 12, y: 55 }, [
+        target("A", 'max by(operation_name,status) (kafka_stream_operation_latency_99p_nanoseconds{job="$cluster_id",operation_type="S3Request"}) / 1000000', "{{operation_name}} / {{status}}"),
+      ], "ms"),
+      timeseries("automq-s3-throughput", "对象存储上传 / 下载吞吐", "AutoMQ 向 OBS 上传和从 OBS 冷读的字节速率。", { h: 9, w: 8, x: 0, y: 64 }, [
+        target("A", 'sum(rate(kafka_stream_upload_size_bytes_total{job="$cluster_id"}[$__rate_interval]))', "上传"),
+        target("B", 'sum(rate(kafka_stream_download_size_bytes_total{job="$cluster_id"}[$__rate_interval]))', "下载"),
+      ], "bytesSecIEC"),
+      timeseries("automq-wal", "WAL 待上传字节", "本地 WAL 中等待上传到对象存储的数据。短暂波动正常，持续上升表示上传能力或对象存储异常。", { h: 9, w: 8, x: 8, y: 64 }, [
+        target("A", 'sum(kafka_stream_wal_pending_upload_bytes{job="$cluster_id"})', "待上传"),
+      ], "bytesIEC"),
+      timeseries("automq-cache", "AutoMQ 内存与缓存", "流缓冲、WAL cache 与 block cache 的实际占用，用于核对 6 GiB cgroup 内的 Tiny 内存基线。", { h: 9, w: 8, x: 16, y: 64 }, [
+        target("A", 'sum(kafka_stream_buffer_allocated_memory_size_bytes{job="$cluster_id"})', "流缓冲"),
+        target("B", 'sum(kafka_stream_delta_wal_cache_size_bytes{job="$cluster_id"})', "WAL cache"),
+        target("C", 'sum(kafka_stream_block_cache_size_bytes{job="$cluster_id"})', "Block cache"),
+      ], "bytesIEC"),
+      timeseries("automq-s3-objects", "S3 对象数量", "按对象状态统计 AutoMQ 管理的 S3 对象数量，用于观察对象增长和 compaction 是否异常。", { h: 9, w: 8, x: 0, y: 73 }, [
+        target("A", 'sum by(state) (kafka_stream_s3_object_count{job="$cluster_id"})', "{{state}}"),
+      ]),
+      timeseries("automq-s3-object-size", "S3 对象容量", "按对象状态统计 AutoMQ 管理的 S3 对象总大小；这是对象层视角，与 Kafka 逻辑日志量口径不同。", { h: 9, w: 8, x: 8, y: 73 }, [
+        target("A", 'sum by(state) (kafka_stream_s3_object_size_bytes{job="$cluster_id"})', "{{state}}"),
+      ], "bytesIEC"),
+      timeseries("automq-backpressure", "AutoMQ 背压与慢 Broker", "背压状态或 slow broker 数量非零表示写入/读取路径正在被限流或节点响应异常。", { h: 9, w: 8, x: 16, y: 73 }, [
+        target("A", 'max(kafka_stream_back_pressure_state{job="$cluster_id"})', "背压状态"),
+        target("B", 'max(kafka_stream_slow_broker_count{job="$cluster_id"})', "慢 Broker"),
+      ]),
+
+      row("row-runtime", "五、KRaft、JVM、宿主机与采集器", 82),
+      timeseries("automq-kraft", "KRaft Leader / Epoch / High Watermark", "KRaft 控制面 Leader、epoch 和高水位。Leader 为 -1 或高水位长时间不推进表示元数据仲裁异常。", { h: 9, w: 8, x: 0, y: 83 }, [
+        target("A", 'max(kafka_server_kraft_current_leader{job="$cluster_id"})', "Leader"),
+        target("B", 'max(kafka_server_kraft_current_epoch{job="$cluster_id"})', "Epoch"),
+        target("C", 'max(kafka_server_kraft_high_watermark{job="$cluster_id"})', "High watermark"),
+      ]),
+      timeseries("automq-kraft-latency", "KRaft 提交延迟", "控制面 Raft 日志提交平均值与最大值。单节点仍需关注磁盘或线程阻塞造成的尖峰。", { h: 9, w: 8, x: 8, y: 83 }, [
+        target("A", 'max(kafka_server_kraft_commit_latency_avg_milliseconds{job="$cluster_id"})', "平均"),
+        target("B", 'max(kafka_server_kraft_commit_latency_max_milliseconds{job="$cluster_id"})', "最大"),
+      ], "ms"),
+      timeseries("automq-event-queue", "Controller 事件队列 P99", "控制器事件排队和处理第 99 百分位耗时；排队高而处理低通常是线程繁忙，二者都高需查资源与存储。", { h: 9, w: 8, x: 16, y: 83 }, [
+        target("A", 'max(kafka_event_queue_time_99p_milliseconds{job="$cluster_id"})', "排队"),
+        target("B", 'max(kafka_event_queue_processing_time_99p_milliseconds{job="$cluster_id"})', "处理"),
+      ], "ms"),
+      timeseries("automq-jvm-memory", "JVM 内存使用", "JVM 各内存池使用量。显式 Heap/Direct 之外还需为 native、线程栈、ZGC 和网络缓冲保留空间。", { h: 9, w: 8, x: 0, y: 92 }, [
+        target("A", 'sum by(area,type) (jvm_memory_used_bytes{job="$cluster_id"})', "{{area}} / {{type}}"),
+      ], "bytesIEC"),
+      timeseries("automq-jvm-cpu-gc", "JVM CPU 与 GC", "进程 CPU 利用率和平均 GC 停顿。GC 持续升高时结合内存占用与宿主机压力判断。", { h: 9, w: 8, x: 8, y: 92 }, [
+        target("A", 'max(jvm_cpu_recent_utilization_ratio{job="$cluster_id"})', "CPU"),
+        target("B", 'sum(rate(jvm_gc_duration_seconds_sum{job="$cluster_id"}[$__rate_interval])) / clamp_min(sum(rate(jvm_gc_duration_seconds_count{job="$cluster_id"}[$__rate_interval])),1)', "平均 GC 秒"),
+      ]),
+      timeseries("automq-host", "AutoMQ 宿主机 CPU / 内存使用率", "只匹配 automq_host=true 的 node-exporter，避免把其他节点资源混入。", { h: 9, w: 8, x: 16, y: 92 }, [
+        target("A", '1 - avg(rate(node_cpu_seconds_total{automq_host="true",mode="idle"}[$__rate_interval]))', "CPU"),
+        target("B", '1 - (node_memory_MemAvailable_bytes{automq_host="true"} / node_memory_MemTotal_bytes{automq_host="true"})', "内存"),
+      ], "percentUnit", 0.8, 0.9),
+      timeseries("automq-vmagent-health", "vmagent 抓取与 Remote Write 健康", "抓取失败或 Remote Write 待发送数据持续增长时，夜莺看到的曲线可能滞后，不能误判为被监控服务无流量。", { h: 9, w: 12, x: 0, y: 101 }, [
+        target("A", 'sum by(job) (rate(vm_promscrape_scrapes_failed_total{job="automq-vmagent"}[$__rate_interval]))', "抓取失败 {{job}}"),
+        target("B", 'sum(vmagent_remotewrite_pending_data_bytes{job="automq-vmagent"})', "Remote Write 待发送字节"),
+      ]),
+      timeseries("automq-jvm-threads", "JVM 线程数", "AutoMQ JVM 当前平台线程数。持续单向增长可能表示线程泄漏或连接/任务堆积。", { h: 9, w: 12, x: 12, y: 101 }, [
+        target("A", 'max(jvm_thread_count{job="$cluster_id"})', "Threads"),
+      ]),
     ],
   },
 };

--- a/scripts/validate-automq.sh
+++ b/scripts/validate-automq.sh
@@ -48,11 +48,15 @@ validate_static() {
       "${root}/config/obs-lifecycle.json" \
       "${root}/config/prometheus.yml.template" \
       "${root}/monitoring/nightingale/automq-cluster.json" \
+      "docker-compose/victorialogs/monitoring/README.md" \
+      "docker-compose/victorialogs/monitoring/grafana/victorialogs-v1.52.0.json" \
+      "docker-compose/victorialogs/monitoring/nightingale/victorialogs-v1.52.0.json" \
       "docs/decisions/0002-automq-object-storage-log-buffer.md" \
       "docs/images/automq-dashboard-overview.png" \
       "scripts/render-automq-vector-manifest.py" \
       "scripts/render-automq-example-manifests.py" \
       "scripts/render-automq-nightingale-dashboard.mjs" \
+      "scripts/vendor-victorialogs-dashboard.mjs" \
       "k8s-deployment/vector/vvg/automq-containerd-production.yaml" \
       "k8s-deployment/vector/gateway/automq-containerd-production.yaml" \
       "scripts/requirements-automq.txt"; do
@@ -118,6 +122,14 @@ validate_static() {
     "vmagent reads the VictoriaMetrics password from a secret file"
   forbid_regex "${compose}" 'remoteWrite\.basicAuth\.(username|password)=' \
     "vmagent Compose contains no inline remote-write credentials"
+  require_literal "${env}" 'VICTORIALOGS_METRICS_TARGET=victorialogs.example.internal:9428' \
+    "AutoMQ environment declares a sanitized VictoriaLogs metrics target"
+  require_literal "${root}/config/prometheus.yml.template" 'job_name: victorialogs' \
+    "vmagent scrapes VictoriaLogs metrics"
+  require_literal "${root}/config/prometheus.yml.template" '__VICTORIALOGS_METRICS_TARGET__' \
+    "VictoriaLogs metrics target is rendered from the environment"
+  require_literal "${root}/config/prometheus.yml.template" 'job_name: automq-vmagent' \
+    "vmagent scrapes its own health metrics"
   require_literal "${server}" 's3.wal.cache.size=524288000' \
     "AutoMQ WAL cache uses the official Tiny value"
   require_literal "${server}" 's3.block.cache.size=104857600' \
@@ -295,15 +307,45 @@ import json, sys
 dashboard = json.load(open(sys.argv[1], encoding="utf-8"))
 assert dashboard["ident"] == "automq-production-cluster"
 panels = dashboard["configs"]["panels"]
-assert len(panels) >= 12
+assert len(panels) >= 35
 assert all(panel["type"] != "unknown" for panel in panels)
+assert sum(panel["type"] == "row" for panel in panels) >= 5
+assert all(panel.get("name") for panel in panels)
+assert all(panel.get("description") for panel in panels if panel["type"] != "row")
+assert all(
+    panel.get("options", {}).get("standardOptions", {}).get("unit") is not None
+    for panel in panels if panel["type"] != "row"
+)
 assert any("vector_kafka_consumer_lag" in target["expr"] for panel in panels for target in panel["targets"])
 assert any("vector_buffer_size_bytes" in target["expr"] for panel in panels for target in panel["targets"])
+assert any("kafka_stream_wal_pending_upload_bytes" in target["expr"] for panel in panels for target in panel["targets"])
 PY
   then
     pass "Nightingale dashboard uses supported panels and covers lag and producer buffers"
   else
     fail "Nightingale dashboard structure is invalid"
+  fi
+  if command -v node >/dev/null 2>&1; then
+    if node scripts/render-automq-nightingale-dashboard.mjs --check; then
+      pass "Nightingale AutoMQ dashboard matches its renderer"
+    else
+      fail "Nightingale AutoMQ dashboard must be freshly rendered"
+    fi
+    if node scripts/vendor-victorialogs-dashboard.mjs --check; then
+      pass "VictoriaLogs dashboard matches the official v1.52.0 artifact"
+    else
+      fail "VictoriaLogs dashboard provenance or structure is invalid"
+    fi
+  else
+    pass "Node unavailable; Nightingale dashboard passed structural validation"
+    if printf '%s  %s\n' \
+      '07a17ece43627672bdc8335a6e51a881c11ae58f184f51623094e204d84be569' \
+      'docker-compose/victorialogs/monitoring/grafana/victorialogs-v1.52.0.json' \
+      | sha256sum -c - >/dev/null; then
+      pass "VictoriaLogs dashboard matches the official v1.52.0 SHA-256"
+    else
+      fail "VictoriaLogs dashboard SHA-256 is invalid"
+    fi
   fi
   require_literal "${root}/README.md" '不得放入' \
     "AutoMQ monitoring is owned by the Jinling Cloud SaaS project"

--- a/scripts/vendor-victorialogs-dashboard.mjs
+++ b/scripts/vendor-victorialogs-dashboard.mjs
@@ -1,0 +1,90 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const version = "v1.52.0";
+const expectedSha256 = "07a17ece43627672bdc8335a6e51a881c11ae58f184f51623094e204d84be569";
+const upstream = `https://raw.githubusercontent.com/VictoriaMetrics/VictoriaLogs/${version}/dashboards/victorialogs.json`;
+const root = resolve(import.meta.dirname, "..");
+const output = resolve(root, "docker-compose/victorialogs/monitoring/grafana/victorialogs-v1.52.0.json");
+const nightingaleOutput = resolve(root, "docker-compose/victorialogs/monitoring/nightingale/victorialogs-v1.52.0.json");
+
+const sha256 = (content) => createHash("sha256").update(content).digest("hex");
+
+const validate = (content) => {
+  const actualSha256 = sha256(content);
+  if (actualSha256 !== expectedSha256) {
+    throw new Error(`VictoriaLogs dashboard SHA-256 mismatch: ${actualSha256}`);
+  }
+
+  const dashboard = JSON.parse(content.toString("utf8"));
+  const allPanels = [];
+  const visit = (panels) => {
+    for (const panel of panels) {
+      allPanels.push(panel);
+      if (panel.panels) visit(panel.panels);
+    }
+  };
+  visit(dashboard.panels);
+
+  if (dashboard.title !== "VictoriaLogs - single-node" || dashboard.uid !== "OqPIZTX4z") {
+    throw new Error("Unexpected VictoriaLogs dashboard identity");
+  }
+  if (dashboard.time?.from !== "now-3h" || allPanels.length !== 73) {
+    throw new Error("Unexpected VictoriaLogs dashboard layout or default range");
+  }
+  if (!allPanels.some((panel) => panel.title === "Logs ingestion rate")) {
+    throw new Error("VictoriaLogs ingestion panel is missing");
+  }
+  if (!allPanels.some((panel) => panel.title === "Query duration p99")) {
+    throw new Error("VictoriaLogs query latency panel is missing");
+  }
+};
+
+const validateNightingale = () => {
+  const dashboard = JSON.parse(readFileSync(nightingaleOutput, "utf8"));
+  if (dashboard.name !== "VictoriaLogs 生产监控（官方 v1.52.0 单机版）") {
+    throw new Error("Unexpected Nightingale VictoriaLogs dashboard name");
+  }
+  if (dashboard.ident !== "victorialogs-production-monitoring") {
+    throw new Error("Unexpected Nightingale VictoriaLogs dashboard identity");
+  }
+
+  const panels = [];
+  const visit = (items) => {
+    for (const panel of items) {
+      panels.push(panel);
+      if (panel.panels) visit(panel.panels);
+    }
+  };
+  visit(dashboard.configs.panels);
+  if (panels.length !== 73 || panels.some((panel) => panel.type === "unknown")) {
+    throw new Error("Nightingale must preserve all 73 supported VictoriaLogs panels");
+  }
+  const flags = panels.find((panel) => panel.name === "Non-default flags（非默认启动参数）");
+  if (flags?.type !== "barGauge") {
+    throw new Error("Nightingale non-default flags panel must use barGauge");
+  }
+  const datasourceVariables = dashboard.configs.var.filter(
+    (variable) => variable.type === "datasource" && variable.name === "DS_PROMETHEUS",
+  );
+  if (datasourceVariables.length !== 1) {
+    throw new Error("Nightingale dashboard must contain one Prometheus datasource variable");
+  }
+};
+
+if (process.argv.includes("--check")) {
+  validate(readFileSync(output));
+  validateNightingale();
+  console.log(`Verified VictoriaLogs ${version} Grafana and Nightingale dashboards (${expectedSha256})`);
+} else {
+  const response = await fetch(upstream);
+  if (!response.ok) {
+    throw new Error(`Unable to download VictoriaLogs dashboard: HTTP ${response.status}`);
+  }
+  const content = Buffer.from(await response.arrayBuffer());
+  validate(content);
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, content);
+  console.log(`Vendored VictoriaLogs ${version} dashboard (${expectedSha256})`);
+}


### PR DESCRIPTION
## Summary

- replace the sparse AutoMQ Nightingale view with a 42-panel native dashboard based on AutoMQ 1.7.4 official metrics
- add clear panel names, descriptions, health thresholds, and human-readable units for cluster, traffic, lag, S3/WAL, KRaft, JVM, host, and vmagent signals
- vendor the official VictoriaLogs v1.52.0 single-node Grafana dashboard with a pinned SHA-256 and provide a Nightingale v9.1.1 native 73-panel conversion
- add VictoriaLogs and vmagent self-scrape jobs to the existing pinned vmagent configuration
- document provenance, import, validation, and rollback boundaries without production addresses or credentials

## Validation

- `node scripts/render-automq-nightingale-dashboard.mjs --check`
- `node scripts/vendor-victorialogs-dashboard.mjs --check`
- `node scripts/validate-vvg-message-filter.mjs`
- `bash scripts/validate-configs.sh --static`
- `git diff --check`
- all 60 AutoMQ dashboard PromQL expressions executed successfully against the production VictoriaMetrics datasource
- VictoriaLogs and vmagent self-monitoring targets verified `up=1`
- AutoMQ, Gateway consumer, Grafana, ClickHouse, and VictoriaLogs were not recreated
- browser validation confirmed the AutoMQ dashboard uses readable KiB/s, GiB, msg/s, req/s, percent, and latency units
- browser validation confirmed the VictoriaLogs dashboard retains 73 panels with no unsupported panel type