### PR TITLE
fix: pin generated dashboard line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 *.sh text eol=lf
 Dockerfile text eol=lf
+docker-compose/automq/monitoring/nightingale/automq-cluster.json text eol=lf
 docker-compose/victorialogs/monitoring/grafana/victorialogs-v1.52.0.json binary
+docker-compose/victorialogs/monitoring/nightingale/victorialogs-v1.52.0.json text eol=lf


### PR DESCRIPTION
## Summary

- force LF checkout for the generated AutoMQ and VictoriaLogs Nightingale JSON files
- keep byte-for-byte generator checks stable on Windows with `core.autocrlf=true`

## Validation

- `node scripts/render-automq-nightingale-dashboard.mjs --check`
- `node scripts/vendor-victorialogs-dashboard.mjs --check`
- `bash scripts/validate-configs.sh --static`
- `git diff --check`