### PR TITLE
docs: explain architecture value and component capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # VVG 日志收集系统
 
-VVG 是本仓库的核心日志系统，面向应用原始日志检索、Java 多行日志、message 多条件过滤和可视化排障。主链路为：
+> 用一套开放、可验证、可回滚的日志链路，把高吞吐采集、低成本存储和快速排障能力交给每一个研发与运维团队。
+
+VVG 是面向 Kubernetes、容器和传统主机的高性能日志平台。它不是简单拼接几个开源组件，
+而是围绕真实生产问题，把采集、缓冲、存储、检索、可视化和监控拆成清晰的职责边界。
+默认主链路保持轻量：
 
 ```text
 Vector -> VictoriaLogs -> Grafana
@@ -14,7 +18,31 @@ MCP Client -> mcp-victorialogs -> vmauth -> VictoriaLogs
 
 核心验证基线：Vector `0.58.0`、VictoriaLogs `v1.52.0`、Grafana `13.2.0-ubuntu`、VictoriaLogs datasource `0.31.0`、Business Text `6.3.0`、VictoriaLogs MCP `v1.9.0`、vmauth `v1.151.0`。Grafana 插件采用版本化宿主机 release 目录和只读挂载，与 Grafana 镜像解耦，正式启动不联网安装。
 
-仓库后半部分另提供独立的 [Gateway 结构化日志分析附加方案](#附加方案gateway-结构化日志分析)。该方案使用 ClickHouse，不与 VVG 的 VictoriaLogs 原始日志链路混合部署或混合变更。
+## 项目背景
+
+微服务数量增长以后，日志系统通常会同时遇到四类挑战：容器日志轮转快、Java 堆栈容易
+被拆散；流量峰值或后端维护会放大积压；传统全文检索集群资源开销和运维复杂度较高；
+而研发真正需要的是快速缩小范围、看到上下文并立即定位问题，而不是先学习一套复杂语法。
+
+VVG 因此采用“主链路轻量、缓冲层可选、分析链路分离、监控独立”的设计：小到中等规模
+直接写入 VictoriaLogs，减少组件和故障面；吞吐或可靠性需求提升后再加入 AutoMQ；
+Gateway 结构化访问日志使用 ClickHouse 做实时聚合；运行指标通过 vmagent 写入
+VictoriaMetrics，再由夜莺统一展示和告警。
+
+## 为什么选择这套架构
+
+| 设计原则 | 实现方式 | 带来的价值 |
+|---|---|---|
+| 数据入口保持开放 | Vector 统一采集、解析、脱敏和路由 | 同一份日志可投递到 VictoriaLogs、AutoMQ、ClickHouse 等后端，降低厂商锁定风险 |
+| 默认路径足够简单 | Vector 直接写 VictoriaLogs | 组件少、部署快、资源利用率高，适合大多数小到中等规模场景 |
+| 扩容不推翻原方案 | 中大规模按需加入 AutoMQ + 对象存储 | 吸收流量尖峰、支持 Kafka offset 重放，并把长期容量交给价格更低的对象存储 |
+| 原始检索与结构化分析分工 | VictoriaLogs 保存原始日志，ClickHouse 分析 Gateway 结构化事件 | 全文检索和实时聚合各用擅长的引擎，避免一套存储承担所有负载 |
+| 展示和告警各取所长 | Grafana 服务研发检索，夜莺负责运行监控与告警 | 既保留灵活查询体验，也具备业务组、规则、通知和恢复状态管理 |
+| 可靠性可以验证和回滚 | checkpoint、disk buffer、acknowledgement、固定版本和 CI 校验 | 每次部署都有明确边界、验证证据和回滚入口，不依赖现场手工记忆 |
+
+仓库后半部分提供独立的[运行监控附加方案](#附加方案automq-与-victorialogs-运行监控)
+和 [Gateway 结构化日志分析附加方案](#附加方案gateway-结构化日志分析)。附加能力不会改变
+VVG 原始日志主链路，也不会强迫较小环境承担不必要的复杂度。
 
 ## 日志链路选型
 
@@ -46,32 +74,115 @@ VVG 直写基线位于 `k8s-deployment/vector/vvg/direct-containerd.yaml`，Gate
 
 ## VVG 核心架构
 
-```
-┌─────────────────────┐    ┌──────────────────────┐     ┌─────────────────────┐
-│                     │    │                      │     │                     │
-│      Vector         │────│    VictoriaLogs      │──── │      Grafana        │
-│   (日志收集器)       │    │     (日志存储)       │     │    (日志可视化)      │
-│                     │    │                      │     │                    │
-│  • Nginx 日志       │    │  • 高性能存储         │     │  • 查询界面         │
-│  • Java 多行日志    │    │  • 数据压缩           │     │  • 仪表板           │
-│  • 数据处理和转换    │    │  • 快速检索           │    │  • 告警功能          │
-│                     │    │                      │    │                     │
-└─────────────────────┘    └──────────────────────┘    └─────────────────────┘
-         :8686                       :9428                       :3000
+```mermaid
+flowchart TB
+    subgraph sources[日志来源]
+        direction LR
+        APP[应用与中间件]
+        K8S[Kubernetes / CRI]
+        HOST[主机文件]
+    end
+
+    subgraph collect[采集与治理]
+        direction LR
+        VECTOR[Vector<br/>多行合并 · 结构化 · 脱敏<br/>checkpoint · disk buffer · backpressure]
+    end
+
+    subgraph delivery[两种交付路径]
+        direction LR
+        DIRECT[默认直写<br/>小到中等规模]
+        AUTOMQ[可选 AutoMQ 集群<br/>推荐 3+ Controller/Broker]
+        OBJECT[(S3 / OBS 对象存储)]
+        CONSUMER[Vector consumer<br/>Kafka offset 重放]
+    end
+
+    subgraph logs[原始日志存储与检索]
+        direction LR
+        VL[(VictoriaLogs<br/>压缩存储 · LogsQL · 高基数)]
+        GRAFANA[Grafana<br/>多条件检索 · 趋势 · 高亮]
+    end
+
+    subgraph monitor[独立运行监控]
+        direction LR
+        VMAGENT[vmagent<br/>抓取 · 过滤 · 磁盘队列]
+        VM[(VictoriaMetrics)]
+        N9E[Nightingale<br/>大屏 · 告警 · 通知]
+    end
+
+    APP --> VECTOR
+    K8S --> VECTOR
+    HOST --> VECTOR
+    VECTOR --> DIRECT --> VL
+    VECTOR -. 按需启用 .-> AUTOMQ
+    AUTOMQ <--> OBJECT
+    AUTOMQ --> CONSUMER --> VL
+    VL --> GRAFANA
+
+    VECTOR -. /metrics .-> VMAGENT
+    AUTOMQ -. /metrics .-> VMAGENT
+    VL -. /metrics .-> VMAGENT
+    VMAGENT --> VM --> N9E
+
+    classDef source fill:#f3f4f6,stroke:#6b7280,color:#111827
+    classDef collector fill:#dcfce7,stroke:#16a34a,color:#14532d
+    classDef buffer fill:#fef3c7,stroke:#d97706,color:#78350f
+    classDef storage fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
+    classDef interface fill:#ede9fe,stroke:#7c3aed,color:#4c1d95
+    classDef monitoring fill:#ffe4e6,stroke:#e11d48,color:#881337
+    style sources fill:#ffffff,stroke:#cbd5e1,stroke-width:1px
+    style collect fill:#ffffff,stroke:#cbd5e1,stroke-width:1px
+    style delivery fill:#ffffff,stroke:#cbd5e1,stroke-width:1px
+    style logs fill:#ffffff,stroke:#cbd5e1,stroke-width:1px
+    style monitor fill:#ffffff,stroke:#cbd5e1,stroke-width:1px
+    class APP,K8S,HOST source
+    class VECTOR collector
+    class DIRECT,AUTOMQ,OBJECT,CONSUMER buffer
+    class VL,VM storage
+    class GRAFANA interface
+    class VMAGENT,N9E monitoring
 ```
 
-## 核心特性
+实线是正常数据流，虚线是按需启用或监控采集。默认直写路径最短、组件最少；AutoMQ
+集群只在需要集中缓冲、削峰和重放时加入。图中的 `3+ Controller/Broker` 是官方生产
+高可用方向，本仓库当前单节点 Compose 仍是受控例外，不能等同于该集群形态。
 
-- **🚀 高性能**: VictoriaLogs 提供极高的写入和查询性能
-- **📦 轻量级**: 相比 ELK 栈，资源占用更少
-- **🔧 易部署**: Docker Compose 一键部署，vector支持kubernetes分布式部署
-- **📊 可视化**: Grafana 提供强大的日志查询和可视化功能
-- **🔍 智能解析**: 自动识别 Nginx 和 Java 日志格式
-- **🔄 可靠传输**: 持久磁盘缓冲、背压和可回滚升级，后端短时维护不主动丢新日志
-- **🧩 多条件检索**: message 包含/不包含、全局 AND/OR、显式 Apply/Reset、URL 状态恢复
-- **📈 清晰趋势**: 复用 Explore Logs volume 的连续时间桶，宽时间范围仍保持可读柱形
-- **⚡ 查询保护**: 默认 15 分钟、All 展开为 `*`、明细 500 行、输入期间零查询
-- **🔒 可审计插件**: 精确版本、SHA-256、不可变 release、只读挂载和原子回滚
+## 官方组件能力
+
+| 组件 | 官方能力 | 在 VVG 中的角色 |
+|---|---|---|
+| [Vector](https://vector.dev/docs/introduction/) | 官方定位为高性能可观测数据管道，可统一采集、转换和路由日志、指标与链路数据；支持背压、磁盘缓冲和 acknowledgement。官方公开介绍给出的性能是相对替代方案最高可达 `10 倍`。 | 在节点侧完成多行合并、结构化、脱敏、分流和可靠发送，让数据入口不绑定某个存储厂商。 |
+| [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/) | 面向日志优化的开源存储，支持高基数字段、乱序写入、全文检索和 LogsQL 分析；单二进制即可运行，也支持横向集群。官方 benchmark 口径显示，相比 Elasticsearch 或 Grafana Loki，内存占用最高可低至 `1/30`，磁盘占用最高可低至 `1/15`。 | 作为 VVG 原始日志主存储，以更少资源承载更长保留周期，并为 Grafana 提供快速查询。 |
+| [AutoMQ](https://docs.automq.com/automq/what-is-automq/overview) | 完全兼容 Kafka 协议，以 S3 对象存储替代本地盘数据副本，支持秒级弹性。官方介绍给出的目标是最高降低 `90%` 存储成本、获得 `10 倍` TCO 优势。 | 作为中大规模环境的可选持久缓冲层，隔离采集端与后端波动，并依靠 offset 支持消费者重放。 |
+| [VictoriaMetrics / vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/) | VictoriaMetrics 面向高性能、低成本时序存储；vmagent 同时支持 Prometheus 抓取和 Remote Write，并可在远端不可用时把待发送指标持久化到磁盘队列。 | 低资源采集 AutoMQ、Vector、VictoriaLogs 和主机指标，为夜莺大屏与告警提供统一数据源。 |
+| [Grafana](https://grafana.com/docs/grafana/latest/visualizations/explore/) | 提供成熟的 Dashboard 与 Explore 体验，可以直接查询、分析和聚合数据，并通过数据源生态连接不同后端。 | 面向研发排障，提供 namespace、服务、Pod、级别和 message 多条件检索以及日志上下文阅读。 |
+| [Nightingale](https://github.com/ccfos/nightingale) | 官方定位为开源告警专家，支持多数据源、业务组、告警规则、屏蔽、订阅、通知、事件管道和常用可视化面板。 | 面向运维值守，统一展示 AutoMQ 与 VictoriaLogs 运行状态，并承载告警和恢复闭环。 |
+| [ClickHouse](https://clickhouse.com/use-cases/real-time-analytics) | 列式存储、压缩和并行查询执行适合大规模实时分析，可垂直或水平扩展到高吞吐分析场景。 | 作为 Gateway 附加方案的结构化日志分析引擎，不与 VictoriaLogs 原始日志链路混用。 |
+
+上表中的性能和成本数字来自各项目官方公开 benchmark 或产品介绍，不是 VVG 对任意环境的
+固定 SLA。实际收益取决于日志大小、字段基数、查询模式、保留周期、硬件和对象存储价格；
+仓库建议先用真实流量影子验证，再根据测量结果扩容或切换。当前 AutoMQ 单节点 Compose
+是明确接受的受控例外，只提供缓冲和重放能力，不代表 AutoMQ 官方多节点生产高可用架构。
+
+## 核心收益
+
+- **更高吞吐**：采集、缓冲和查询层各自独立扩展，避免单个组件同时承担解析、存储和展示压力。
+- **更低成本**：默认链路不需要庞大的搜索集群；高容量场景可利用 VictoriaLogs 压缩和对象存储成本优势。
+- **更快排障**：开箱即用的日志工作台支持多条件过滤、匹配高亮、连续趋势和 URL 状态恢复。
+- **更稳交付**：checkpoint、磁盘缓冲、背压、Kafka offset 和下游 acknowledgement 在各自支持边界内共同吸收后端抖动与维护窗口。
+- **更易运维**：精确版本、离线插件、受控资源、静态校验、脱敏资产、备份和运行手册均已进入 Git。
+- **平滑演进**：先从轻量直写开始，规模增长后再启用 AutoMQ；需要实时业务分析时独立组合 ClickHouse。
+
+### 适合这些场景
+
+- Kubernetes 或容器日志量持续增长，希望控制 Elasticsearch/Loki 类方案的资源和存储成本。
+- 需要正确合并 Java 堆栈、保留真实事件时间，并快速按 namespace、服务、Pod 和 message 排障。
+- 后端存在升级或维护窗口，希望用磁盘缓冲、背压或 AutoMQ 削峰并支持重放。
+- 既要研发友好的日志检索，也要运维统一监控、告警和恢复状态追踪。
+- 希望先以单机或直写方案低成本起步，再平滑扩展到对象存储缓冲与结构化实时分析。
+
+如果你正在替换资源占用较高的 ELK/Loki 链路，或希望为 Kubernetes 日志建立一套可审计、
+可扩展的开源基线，可以先按[快速开始](#快速开始)部署直写方案，再根据
+[日志链路选型指南](docs/log-pipeline-selection.md)逐步启用缓冲、监控和结构化分析能力。
 
 ## 界面预览
 
@@ -109,7 +220,7 @@ VVG 直写基线位于 `k8s-deployment/vector/vvg/direct-containerd.yaml`，Gate
 
 **选项 2: 分布式部署** (推荐)
 - VictoriaLogs: 部署在存储服务器
-- Grafana: 部署在展示服务器  
+- Grafana: 部署在展示服务器
 - Vector: 部署在各个应用服务器
 
 **选项 3: Kubernetes 部署** ⭐ 推荐
@@ -188,7 +299,7 @@ cd k8s-deployment
 # Docker CRI
 kubectl apply -f vector/vvg/direct-docker.yaml
 
-# Containerd CRI  
+# Containerd CRI
 kubectl apply -f vector/vvg/direct-containerd.yaml
 
 # 3. 验证部署
@@ -285,7 +396,7 @@ Pull Request 和 `main` 分支会通过 GitHub Actions 重复执行完整校验�
 每个服务的配置文件都位于对应目录下的 `env.example`，使用前需要复制为 `.env` 并修改相关参数:
 
 - **VictoriaLogs**: 端口、数据保留期、存储路径
-- **Grafana**: VictoriaLogs 地址、管理员密码、端口  
+- **Grafana**: VictoriaLogs 地址、管理员密码、端口
 - **Vector (Docker Compose)**: VictoriaLogs 地址、日志文件路径、主机标识
 - **Vector (Kubernetes)**: VictoriaLogs 地址、Java 多行日志增强处理、高性能缓冲配置
 
@@ -311,7 +422,7 @@ Pull Request 和 `main` 分支会通过 GitHub Actions 重复执行完整校验�
 
 支持的自定义内容:
 - 添加新的日志源
-- 修改日志解析规则  
+- 修改日志解析规则
 - 自定义数据处理逻辑
 - 配置日志过滤条件
 - Java 多行日志匹配规则
@@ -376,12 +487,35 @@ Gateway访问日志仍是独立的数据链路，但部署文件按服务归位�
 
 该模板不会携带现场地址或凭据，并通过 CI 阻止有限重试、无界 system log、非持久 buffer、`latest`、华为云下载链接和真实环境标识回流仓库。
 
-```text
-Gateway stdout -> Vector 0.58 -> ClickHouse 26.8 LTS -> Grafana
-                     |               |
-                     |               +-- 月分区 / 紧凑主键 / 30 天业务 TTL
-                     +-- checkpoint / 1 GiB disk buffer / 180 秒可靠重试 / GeoIP
+```mermaid
+flowchart TB
+    GW[Gateway stdout<br/>超长多行 JSON] --> VECTOR[Vector 0.58<br/>完整读取 · 解析 · 脱敏 · GeoIP]
+    GEO[(DB-IP City Lite<br/>固定版本与 SHA-256)] --> VECTOR
+
+    VECTOR -->|默认直写| CH[(ClickHouse 26.8 LTS<br/>月分区 · 紧凑主键 · 30 天 TTL)]
+    VECTOR -. 中大规模可选 .-> MQ[AutoMQ 集群<br/>仅接收解析脱敏后的事件]
+    MQ <--> OBJ[(S3 / OBS 对象存储)]
+    MQ --> CONSUMER[Vector consumer<br/>offset 重放 · memory buffer]
+    CONSUMER --> CH
+    VECTOR -->|超过 Kafka 4 MiB 边界| FALLBACK[受控直写 fallback]
+    FALLBACK --> CH
+    CH --> GRAFANA[Grafana Gateway 大屏<br/>实时聚合 · GeoIP · 明细检索]
+
+    classDef source fill:#f3f4f6,stroke:#6b7280,color:#111827
+    classDef collector fill:#dcfce7,stroke:#16a34a,color:#14532d
+    classDef buffer fill:#fef3c7,stroke:#d97706,color:#78350f
+    classDef storage fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
+    classDef interface fill:#ede9fe,stroke:#7c3aed,color:#4c1d95
+    class GW,GEO source
+    class VECTOR,CONSUMER collector
+    class MQ,OBJ,FALLBACK buffer
+    class CH storage
+    class GRAFANA interface
 ```
+
+Gateway 原始 header/body 不会进入 AutoMQ 或对象存储；解析、敏感字段处理、事件时间和
+大小门禁都在进入缓冲层之前完成。直写与 AutoMQ production producer 清单二选一，
+不能同时发送同一批正式日志。
 
 附加方案文档：
 
@@ -412,4 +546,4 @@ Gateway stdout -> Vector 0.58 -> ClickHouse 26.8 LTS -> Grafana
 
 ---
 
-**注意**: 生产环境部署前请仔细阅读各服务的部署文档，确保正确配置安全和性能参数。 
+**注意**: 生产环境部署前请仔细阅读各服务的部署文档，确保正确配置安全和性能参数。

--- a/scripts/validate-configs.sh
+++ b/scripts/validate-configs.sh
@@ -124,6 +124,33 @@ validate_static() {
     "README displays the dashboard overview"
   require_literal "README.md" 'docs/images/vvg-message-filter-builder.png' \
     "README displays the message filter builder"
+  require_literal "README.md" '## 项目背景' \
+    "README explains the project background"
+  require_literal "README.md" '## 为什么选择这套架构' \
+    "README explains the architecture decision"
+  require_literal "README.md" '## 官方组件能力' \
+    "README documents official component capabilities"
+  if [[ "$(grep -Fc '```mermaid' README.md)" -ge 2 ]]; then
+    pass "README includes the core and Gateway Mermaid architecture diagrams"
+  else
+    fail "README must include both Mermaid architecture diagrams"
+  fi
+  require_literal "README.md" 'AUTOMQ[可选 AutoMQ 集群' \
+    "VVG architecture includes the optional AutoMQ cluster"
+  require_literal "README.md" 'MQ --> CONSUMER[Vector consumer' \
+    "Gateway architecture includes the buffered consumer path"
+  require_literal "README.md" 'Gateway 原始 header/body 不会进入 AutoMQ 或对象存储' \
+    "Gateway architecture documents the pre-buffer redaction boundary"
+  require_literal "README.md" 'https://vector.dev/docs/introduction/' \
+    "README links the official Vector introduction"
+  require_literal "README.md" 'https://docs.victoriametrics.com/victorialogs/' \
+    "README links the official VictoriaLogs documentation"
+  require_literal "README.md" 'https://docs.automq.com/automq/what-is-automq/overview' \
+    "README links the official AutoMQ overview"
+  require_literal "README.md" 'https://github.com/ccfos/nightingale' \
+    "README links the official Nightingale repository"
+  require_literal "README.md" '官方公开 benchmark' \
+    "README qualifies upstream performance and cost claims"
   require_literal "README.md" 'docs/ai-agent-operations-guide.md' \
     "README links the AI agent operations guide"
   require_literal "README.md" 'docs/grafana-victorialogs-研发现场日志查询%20&%20过滤手册.md' \


### PR DESCRIPTION
## Summary

- add a concise project background that explains the production logging problems VVG is designed to solve
- document why the default direct path stays simple and when AutoMQ, ClickHouse, and independent monitoring should be added
- describe the official capabilities and project roles of Vector, VictoriaLogs, AutoMQ, VictoriaMetrics/vmagent, Grafana, Nightingale, and ClickHouse
- qualify all upstream benchmark and cost claims and retain the single-node AutoMQ non-HA boundary
- replace the old ASCII VVG diagram with a styled Mermaid architecture showing direct delivery, an optional AutoMQ cluster, object storage, replay consumers, and the independent monitoring path
- replace the Gateway ASCII diagram with a Mermaid flow showing direct writes, buffered delivery, GeoIP, and the 4 MiB fallback boundary
- add static safeguards for the new narrative, official sources, and architecture boundaries

## Validation

- both Mermaid diagrams rendered successfully with `@mermaid-js/mermaid-cli 11.17.0`
- `node scripts/render-automq-nightingale-dashboard.mjs --check`
- `node scripts/vendor-victorialogs-dashboard.mjs --check`
- `bash scripts/validate-configs.sh --static`
- `git diff --check`
- all seven official source links returned HTTP 200
- production-address scan returned no matches