### PR TITLE
fix: 修复 AutoMQ 冷启动与消费者恢复，并完善回归验证

### DIFF
--- a/docker-compose/automq/README.md
+++ b/docker-compose/automq/README.md
@@ -72,8 +72,20 @@ docker compose --env-file .env --profile shadow up -d
 ```
 
 `automq-init` 只在空 KRaft 目录执行 format，并把 admin SCRAM 用户写入 metadata。
-`automq-bootstrap` 幂等创建其余用户、ACL 和两个 Topic。正式消费者使用单独的
-consumer group 与 state 目录：
+`automq-bootstrap` 幂等创建其余用户、ACL 和两个 Topic。首次启动时，它在 Broker
+容器启动后自行等待已认证 Kafka API（每次最多 10 秒、最多 30 次、重试间隔 5 秒），
+再创建 Topic。Broker 健康检查仍要求两个 Topic 存在实际分区且所有 leader 就绪；
+消费者同时等待 bootstrap 成功和 Broker healthy。不能让 bootstrap 等待这个包含
+Topic 的健康检查，否则空集群会循环等待。
+
+consumer watchdog 仅管理本机 Compose project `automq` 的消费者。它通过 Kafka
+`--describe --state` 查询成员数，连续两次确认 `Empty / 0` 才优雅重启对应 group；
+查询失败、输出无法识别、零成员 rebalance 或 Broker 不健康会清除连续计数，并继续
+检查另一条链路。`.env` 只读取影子 group 名，沿用示例的独立 `KEY=value` 行（可加一对
+引号，不使用 `export`、行内注释或变量展开），不能作为 shell 执行。远端三个 VVG
+实例不在这个本机 watchdog 的管理范围，应通过监控和目标机的独立恢复流程处理。
+
+正式消费者使用单独的 consumer group 与 state 目录：
 
 ```bash
 docker compose --env-file .env --profile shadow stop \
@@ -96,6 +108,9 @@ docker compose --env-file .env --profile production up -d \
 减少解压后日志的跨机传输。复制 `vvg-consumers.env.example` 为目标机本地 `.env`，填入
 已验证的镜像 digest、VPC 内 Kafka 地址和 VictoriaLogs 地址；`.env` 与 SCRAM password
 必须保持 `0600` 且不得进入 Git。
+
+远端 Compose 同样使用 `pull_policy: never`；启动前必须已在目标机加载并验证精确
+digest 对应的镜像，不能依赖首次启动联网拉取。
 
 三个服务使用同一 production consumer group，但分别使用独立 state 目录和 metrics
 端口。迁移时每次只启动一个新实例，确认 group rebalance、事件收发和错误计数后，再

--- a/docker-compose/automq/docker-compose.vvg-consumers.yml
+++ b/docker-compose/automq/docker-compose.vvg-consumers.yml
@@ -1,5 +1,6 @@
 x-vector-common: &vector-common
   image: ${VECTOR_IMAGE}
+  pull_policy: never
   restart: always
   stop_grace_period: 2m
   read_only: true

--- a/docker-compose/automq/docker-compose.yml
+++ b/docker-compose/automq/docker-compose.yml
@@ -80,7 +80,7 @@ services:
         - CMD-SHELL
         - /opt/automq-deploy/healthcheck-kafka.sh
       interval: 10s
-      timeout: 35s
+      timeout: 45s
       retries: 18
       start_period: 5m
     security_opt:
@@ -93,7 +93,7 @@ services:
     read_only: true
     depends_on:
       automq:
-        condition: service_healthy
+        condition: service_started
     environment:
       VVG_TOPIC: ${VVG_TOPIC}
       GATEWAY_TOPIC: ${GATEWAY_TOPIC}
@@ -113,6 +113,8 @@ services:
     profiles: ["shadow"]
     scale: 3
     depends_on:
+      automq:
+        condition: service_healthy
       automq-bootstrap:
         condition: service_completed_successfully
     environment:
@@ -137,6 +139,8 @@ services:
     profiles: ["shadow"]
     container_name: automq-vector-gateway-shadow
     depends_on:
+      automq:
+        condition: service_healthy
       automq-bootstrap:
         condition: service_completed_successfully
     environment:
@@ -163,6 +167,8 @@ services:
     profiles: ["production"]
     scale: 3
     depends_on:
+      automq:
+        condition: service_healthy
       automq-bootstrap:
         condition: service_completed_successfully
     environment:
@@ -187,6 +193,8 @@ services:
     profiles: ["production"]
     container_name: automq-vector-gateway-production
     depends_on:
+      automq:
+        condition: service_healthy
       automq-bootstrap:
         condition: service_completed_successfully
     environment:

--- a/docker-compose/automq/scripts/bootstrap-cluster.sh
+++ b/docker-compose/automq/scripts/bootstrap-cluster.sh
@@ -5,6 +5,21 @@ bin=/opt/automq/kafka/bin
 bootstrap=automq:19092
 admin_config=/etc/automq/admin-client.properties
 
+# Topic-aware health cannot succeed until this bootstrap has created the topics.
+# Wait for the authenticated API here, with a bounded startup window.
+for attempt in {1..30}; do
+  if timeout 10 "${bin}/kafka-broker-api-versions.sh" \
+      --bootstrap-server "${bootstrap}" --command-config "${admin_config}" \
+      >/dev/null 2>&1; then
+    break
+  fi
+  if [[ "${attempt}" -eq 30 ]]; then
+    printf 'Kafka API did not become ready; bootstrap aborted without changes\n' >&2
+    exit 1
+  fi
+  sleep 5
+done
+
 create_scram_user() {
   local user="$1"
   local password_file="$2"

--- a/docker-compose/automq/scripts/consumer-watchdog.sh
+++ b/docker-compose/automq/scripts/consumer-watchdog.sh
@@ -9,34 +9,69 @@ exec 9>"${state_dir}/lock"
 flock -n 9 || exit 0
 
 cd "${automq_dir}"
-set -a
-# shellcheck disable=SC1091
-. ./.env
-set +a
 
-[[ "$(docker inspect -f '{{.State.Health.Status}}' automq 2>/dev/null || true)" == healthy ]] || exit 0
+# Read only the two group names. Compose dotenv files are not shell programs.
+read_group() {
+  local key="$1" value
+  value="$(sed -n "s/^${key}=//p" .env | tail -n 1)"
+  value="${value%$'\r'}"
+  value="${value#\"}"; value="${value%\"}"
+  value="${value#\'}"; value="${value%\'}"
+  [[ "${value}" =~ ^[A-Za-z0-9._-]+$ ]] || {
+    printf 'Missing or invalid %s in .env\n' "${key}" >&2
+    return 1
+  }
+  printf '%s' "${value}"
+}
+
+if [[ "$(timeout 10 docker inspect -f '{{.State.Health.Status}}' automq 2>/dev/null || true)" != healthy ]]; then
+  # An unknown/down broker interrupts consecutive confirmed-empty observations.
+  rm -f -- "${state_dir}"/*.failures
+  exit 0
+fi
+
+service_ids() {
+  timeout 10 docker ps --filter label=com.docker.compose.project=automq \
+    --filter "label=com.docker.compose.service=$1" --format '{{.ID}}'
+}
 
 check_group() {
   local service="$1"
   local group="$2"
   local counter_file="${state_dir}/${service}.failures"
-  local ids active failures id
+  local ids="$3" description active failures id
   local -a restart_pids=()
-  ids="$(docker ps --filter label=com.docker.compose.project=automq \
-    --filter "label=com.docker.compose.service=${service}" --format '{{.ID}}')"
   if [[ -z "${ids}" ]]; then
     rm -f "${counter_file}"
     return
   fi
-  active="$(docker exec automq /opt/automq/kafka/bin/kafka-consumer-groups.sh \
-    --bootstrap-server automq:19092 --command-config /etc/automq/admin-client.properties \
-    --describe --group "${group}" 2>/dev/null |
-    awk 'NR > 2 && $7 != "-" {seen[$7] = 1} END {for (id in seen) count++; print count + 0}')"
+  if ! description="$(timeout 20 docker exec automq timeout 15 \
+      /opt/automq/kafka/bin/kafka-consumer-groups.sh \
+      --bootstrap-server automq:19092 --command-config /etc/automq/admin-client.properties \
+      --describe --state --group "${group}" 2>/dev/null)"; then
+    rm -f "${counter_file}"
+    printf 'Skipping %s: Kafka group state query failed\n' "${service}" >&2
+    return
+  fi
+  # --state describes membership even when a group has not committed offsets.
+  # Unknown/rebalancing output must never be interpreted as an empty group.
+  active="$(awk -v group="${group}" '
+    $1 == group && NF >= 4 && $NF ~ /^[0-9]+$/ {
+      if ($NF > 0) print $NF
+      else if ($(NF-1) == "Empty") print 0
+    }
+  ' <<<"${description}")"
+  if [[ ! "${active}" =~ ^[0-9]+$ ]]; then
+    rm -f "${counter_file}"
+    printf 'Skipping %s: Kafka group membership is unknown\n' "${service}" >&2
+    return
+  fi
   if [[ "${active}" -gt 0 ]]; then
     printf '0\n' > "${counter_file}"
     return
   fi
   failures="$(cat "${counter_file}" 2>/dev/null || printf '0')"
+  [[ "${failures}" =~ ^[01]$ ]] || failures=0
   failures=$((failures + 1))
   printf '%s\n' "${failures}" > "${counter_file}"
   if [[ "${failures}" -ge 2 ]]; then
@@ -47,19 +82,42 @@ check_group() {
       restart_pids+=("$!")
     done <<<"${ids}"
     for id in "${restart_pids[@]}"; do
-      wait "${id}"
+      if ! wait "${id}"; then
+        printf 'Consumer restart failed for %s\n' "${service}" >&2
+      fi
     done
     printf '0\n' > "${counter_file}"
   fi
 }
 
-if docker ps --filter label=com.docker.compose.service=vector-gateway-production -q | grep -q .; then
-  check_group vector-gateway-production gateway-clickhouse-production-v1
-else
-  check_group vector-gateway-shadow "${GATEWAY_CONSUMER_GROUP}"
-fi
-if docker ps --filter label=com.docker.compose.service=vector-vvg-production -q | grep -q .; then
-  check_group vector-vvg-production vvg-victorialogs-production-v1
-else
-  check_group vector-vvg-shadow "${VVG_CONSUMER_GROUP}"
-fi
+check_pipeline() {
+  local production="$1" group="$2" shadow="$3" shadow_key="$4" ids shadow_group
+  if ! ids="$(service_ids "${production}")"; then
+    rm -f "${state_dir}/${production}.failures" "${state_dir}/${shadow}.failures"
+    return
+  fi
+  if [[ -n "${ids}" ]]; then
+    rm -f "${state_dir}/${shadow}.failures"
+    check_group "${production}" "${group}" "${ids}"
+  else
+    rm -f "${state_dir}/${production}.failures"
+    if ! ids="$(service_ids "${shadow}")"; then
+      rm -f "${state_dir}/${shadow}.failures"
+      return
+    fi
+    if [[ -z "${ids}" ]]; then
+      rm -f "${state_dir}/${shadow}.failures"
+      return
+    fi
+    if ! shadow_group="$(read_group "${shadow_key}")"; then
+      rm -f "${state_dir}/${shadow}.failures"
+      return
+    fi
+    check_group "${shadow}" "${shadow_group}" "${ids}"
+  fi
+}
+
+check_pipeline vector-gateway-production gateway-clickhouse-production-v1 \
+  vector-gateway-shadow GATEWAY_CONSUMER_GROUP
+check_pipeline vector-vvg-production vvg-victorialogs-production-v1 \
+  vector-vvg-shadow VVG_CONSUMER_GROUP

--- a/docker-compose/automq/scripts/healthcheck-kafka.sh
+++ b/docker-compose/automq/scripts/healthcheck-kafka.sh
@@ -14,6 +14,12 @@ for topic in "${VVG_TOPIC}" "${GATEWAY_TOPIC}"; do
     --command-config "${client_config}" \
     --describe \
     --topic "${topic}" 2>/dev/null)"
-  [[ -n "${description}" ]]
-  ! grep -Eq 'Leader: (-1|none)' <<<"${description}"
+  # A summary or warning alone is not evidence of any usable partition.
+  awk '
+    /Partition:[[:space:]]+[0-9]+/ {
+      partitions++
+      if ($0 !~ /Leader:[[:space:]]+[0-9]+([[:space:]]|$)/) bad = 1
+    }
+    END {exit (partitions == 0 || bad)}
+  ' <<<"${description}"
 done

--- a/docs/automq-log-buffer-runbook.md
+++ b/docs/automq-log-buffer-runbook.md
@@ -204,8 +204,14 @@ CPU告警均可产生并恢复。
   新 Pod 必须从同一 ledger 继续排空。
 - Consumer watchdog 先检查 Gateway，再检查 VVG；同一 group 的多个 consumer 并行
   执行 120 秒优雅重启。禁止让影子 VVG 的串行停止窗口阻塞正式 Gateway 的恢复。
+  watchdog 只读取本机 `automq` project，使用 group state 中的成员数；只有连续两次
+  成功查询均为 `Empty / 0` 才重启。Kafka 查询失败、未知输出、零成员 rebalance 和
+  Broker 不健康都打断计数，不能把不可观测状态当成消费者退出。各 group 查询超时有界，
+  一条链路的查询错误不会中止另一条链路的检查；`.env` 不再作为 shell 执行。
 - Broker 健康不能只验证 Kafka API 端口；combined KRaft 重启时端口可能先于业务
   partition leader 就绪。健康检查必须同时确认两个业务 Topic 均无 `Leader: -1`。
+  空集群首次启动时 bootstrap 只等待已认证 API 后建 Topic，消费者再等待 Topic-aware
+  health 和 bootstrap 成功；bootstrap 不能反过来依赖 Topic-aware health。
 - 6 GiB 容器内把 Heap、Direct、WAL 和 Block 按比例放大，在真实 Gateway 主切和 VVG
   积压追赶中两次触发 cgroup OOM。最终保留 3 CPU/6 GiB cgroup，但恢复官方 Tiny 内存
   参数，为 native、线程栈、ZGC、网络和冷读瞬时内存保留约 3 GiB；不得只按各显式
@@ -216,3 +222,7 @@ CPU告警均可产生并恢复。
   单行上限。解析后超过 4 MiB时直写 ClickHouse fallback，且凭据来自 Kubernetes Secret。
 - 生成清单的多行 VRL/命令必须使用 YAML `|` block scalar，并把配置 SHA-256 放入
   Pod annotation，保证可读且 ConfigMap 变化会触发受控滚动。
+- VVG producer 的输入必须继承现场 `sinks.victorialogs.inputs`，保留现场追加的解析、
+  过滤、脱敏步骤和辅助 sink，不能写死为公开示例中的 `add_msg_field`。空 inputs 直接
+  拒绝生成。CI 对 VVG/Gateway 的 shadow/production 四种生成结果都执行真实 Vector
+  配置编译，包括 VRL、Secret 和固定 GeoIP 数据库；YAML 能解析不代表配置可运行。

--- a/docs/repository-audit-2026-09-05.md
+++ b/docs/repository-audit-2026-09-05.md
@@ -1,0 +1,52 @@
+# 仓库检查与可靠性修复（2026-09-05）
+
+检查基线：`3421a2d`。范围是 Git 中的 Compose、Vector 直写与 AutoMQ 生成链路、
+启动/恢复脚本、Grafana 与夜莺资产、MCP 配置边界及 CI。没有连接或修改生产主机，
+因此这份检查不能替代 OBS 实测、生产故障演练或真实流量容量测试。
+
+## 本次修复
+
+| 问题 | 影响 | 修复与验证 |
+|---|---|---|
+| bootstrap 等待包含 Topic 的健康检查 | 空集群中 Topic 尚不存在，创建 Topic 的服务却无法启动 | bootstrap 等待有界的已认证 API 探测，消费者继续等待 bootstrap 完成与 Topic 健康；测试冷启动依赖及 API 延迟/失败 |
+| 健康检查只排除负 leader | 仅含摘要、没有实际分区的输出可能被误判 healthy；原 Compose 超时 35 秒小于三次内部探测最多 40 秒 | 要求至少一条分区记录且每条 leader 为非负整数，外层超时改为 45 秒；覆盖空输出、摘要、负 leader 和部分分区失败 |
+| watchdog 查询失败使脚本整体退出 | Gateway 查询故障阻断 VVG 恢复；查询未知状态与旧计数组合可能导致误重启 | 使用有界 group state 查询，隔离 group 错误，清除非连续计数；只对连续两次 Empty/0 执行原有优雅重启 |
+| watchdog 选服务时未始终限定 project，且执行 `.env` | 其他 project 的同名服务干扰本机判断；配置中的 shell 特殊字符可能被执行 | 所有服务选择限定 `automq` project；只解析必要 group 值，测试跨 project 与命令替换输入 |
+| VVG 生成器写死 `add_msg_field` 并清空所有 sink | 现场追加的脱敏/过滤可能被绕过，辅助 sink 丢失 | 继承真实 Loki sink inputs，只替换目标 sink；shadow/production 都做回归验证，拒绝空输入 |
+| 远端 consumer 缺少禁止拉取策略 | 与离线启动要求不一致 | 三实例继承 `pull_policy: never` |
+| CI 只检查生成清单结构 | 生成的 VRL 或 Vector 配置错误可能通过检查 | 保留结构与防漂移校验，增加四种生产者配置的 Vector 0.58.0 实际编译与 GeoIP SHA-256 校验 |
+
+回归测试位于 `scripts/tests/test_automq_reliability.py`，由现有静态入口自动执行。
+测试使用临时目录与 Kafka/Docker 命令替身验证脚本行为，不向真实集群建 Topic、发日志或
+重启容器。完整容器编译仍由 `--runtime` / GitHub Actions 验证。
+
+## 其他检查结论与后续优先级
+
+| 范围 | 检查结论 / 下一步 |
+|---|---|
+| VVG 直写与日志检索 | 本轮静态校验通过；保留 checkpoint、disk/block、乱序时间、稳定 UID、500 行及 15 分钟限制。Grafana 插件升级必须重新做浏览器请求级验证 |
+| Gateway / ClickHouse | 保留 180 秒写入超时、异步写入确认、固定 GeoIP、脱敏边界和表结构。没有用镜像升级顺带修改 TTL/主键 |
+| MCP | 保留官方组件、独立 Token、固定租户 Header、路径白名单和并发限制。此次未执行真实鉴权/超时穿透测试，不能宣称完成安全认证 |
+| 镜像与依赖 | 保留已固定的版本/digest；本轮没有批量升级。当前缺少真实部署副本和插件浏览器验收条件，更新版本应作为独立兼容性任务 |
+| 单节点 AutoMQ | 仍有 Broker/KRaft/宿主机单点；对象存储不消除控制面单点。需要高可用时另行规划多节点和故障演练 |
+| 本机 VVG 多副本与监控 | 本机 `scale: 3` 仍共享宿主机 state 路径；consumer 当前使用 memory buffer，但应在后续迁移中改为独立目录。远端模板已有独立目录和端口。监控静态 service 名也应改为逐副本发现并按已启用 profile 生成目标，避免漏采和未启用 profile 的持续 down |
+| producer 自动恢复 | 现有 liveness 以高水位且队列不下降判断卡住，持续满负荷时可能与真实卡死混淆；需要结合现场发送速率、lag 与负载回放再调整，不能仅凭配置推断安全阈值 |
+| 首次启动与对象存储 | 回归证明依赖循环已移除，但不替代真实 OBS 小对象、multipart、重启后消息校验和 90 分钟 shadow 门禁 |
+
+## 验证与部署
+
+```bash
+python3 -m pip install -r scripts/requirements-automq.txt
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/tests -v
+bash scripts/validate-configs.sh --static
+bash scripts/validate-configs.sh --runtime
+git diff --check
+```
+
+合并要求：PR 的完整 CI 成功，合并后核对 `main`。实际主机更新仍遵循
+[AutoMQ 运行手册](automq-log-buffer-runbook.md)，先备份再展开 Compose，只更新批准的
+脚本/配置；合并仓库不代表已部署到生产。回滚采用新的 revert PR 和对应主机配置备份，
+不删除 Topic、offset、OBS 对象或生产数据。
+
+依据：[Compose 启动依赖](https://docs.docker.com/compose/how-tos/startup-order/)、
+[Kafka consumer group 管理](https://kafka.apache.org/41/operations/basic-kafka-operations/)。

--- a/scripts/render-automq-vector-manifest.py
+++ b/scripts/render-automq-vector-manifest.py
@@ -171,9 +171,12 @@ def render_vector_config(source: str, pipeline: str, mode: str) -> str:
         direct_sink = copy.deepcopy(sinks.get("victorialogs"))
         if not direct_sink:
             raise SystemExit("VVG source must contain sinks.victorialogs")
+        direct_inputs = direct_sink.get("inputs", [])
+        if not direct_inputs:
+            raise SystemExit("VVG VictoriaLogs sink must have at least one input")
         transforms["prepare_automq_event"] = {
             "type": "remap",
-            "inputs": ["add_msg_field"],
+            "inputs": copy.deepcopy(direct_inputs),
             "source": BlockString(
                 "._automq_event_timestamp = format_timestamp!(.timestamp, \"%+\")\n"
                 "namespace = string(.kubernetes.pod_namespace) ?? \"unknown\"\n"
@@ -234,7 +237,7 @@ def render_vector_config(source: str, pipeline: str, mode: str) -> str:
         ]
         direct_sink["tenant_id"] = "${VLS_TENANT_ID}"
         direct_sink["acknowledgements"] = {"enabled": True}
-        sinks.clear()
+        del sinks["victorialogs"]
         sinks["automq_lane_a"] = kafka_sink(
             ["route_automq_producer_lane.lane_a"], 5368709120
         )

--- a/scripts/tests/test_automq_reliability.py
+++ b/scripts/tests/test_automq_reliability.py
@@ -1,0 +1,254 @@
+"""Offline regressions for startup, recovery and live-manifest conversion.
+
+Only external Kafka/Docker commands are simulated; shell control flow, counters,
+configuration parsing and manifest generation run from the repository scripts.
+"""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+AUTOMQ = ROOT / "docker-compose/automq"
+spec = importlib.util.spec_from_file_location(
+    "automq_renderer", ROOT / "scripts/render-automq-vector-manifest.py"
+)
+renderer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(renderer)
+
+
+class ShellFixture(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.directory = Path(self.temp.name)
+        self.bin = self.directory / "bin"
+        self.bin.mkdir()
+        self.env = {**os.environ, "PATH": f"{self.bin}:{os.environ['PATH']}",
+                    "FIXTURE": str(self.directory)}
+
+    def executable(self, name, source):
+        path = self.bin / name
+        path.write_text(source)
+        path.chmod(0o755)
+        return path
+
+    def run_script(self, path):
+        return subprocess.run(["bash", str(path)], env=self.env,
+                              capture_output=True, text=True, timeout=10)
+
+
+class BootstrapTests(ShellFixture):
+    def test_remote_consumers_never_pull_images_on_startup(self):
+        services = yaml.safe_load((AUTOMQ / "docker-compose.vvg-consumers.yml").read_text())["services"]
+        for name, service in services.items():
+            with self.subTest(service=name):
+                self.assertEqual(service.get("pull_policy"), "never")
+
+    def test_bootstrap_can_run_before_topics_are_healthy(self):
+        services = yaml.safe_load((AUTOMQ / "docker-compose.yml").read_text())["services"]
+        self.assertEqual(services["automq-bootstrap"]["depends_on"]["automq"]["condition"],
+                         "service_started", "Topic creation must not wait for topic health")
+        for name, service in services.items():
+            if name.startswith("vector-"):
+                self.assertEqual(service["depends_on"]["automq"]["condition"], "service_healthy")
+
+    def prepare_bootstrap(self, failed_attempts):
+        self.env.update(VVG_TOPIC="vvg.logs.v1", GATEWAY_TOPIC="gateway.access.v1",
+                        FAILED_ATTEMPTS=str(failed_attempts))
+        secrets = self.directory / "secrets"
+        secrets.mkdir()
+        for name in ("vvg-producer", "gateway-producer", "vvg-consumer", "gateway-consumer"):
+            (secrets / f"{name}-password").write_text("test-password")
+        command = '''#!/usr/bin/env python3
+import os, pathlib, sys
+root = pathlib.Path(os.environ["FIXTURE"])
+name = pathlib.Path(sys.argv[0]).name
+if name == "kafka-broker-api-versions.sh":
+    count = root / "attempts"
+    attempt = int(count.read_text()) + 1 if count.exists() else 1
+    count.write_text(str(attempt))
+    sys.exit(1 if attempt <= int(os.environ["FAILED_ATTEMPTS"]) else 0)
+with (root / "mutations").open("a") as stream:
+    stream.write(name + "\\n")
+'''
+        for name in ("kafka-broker-api-versions.sh", "kafka-configs.sh", "kafka-topics.sh", "kafka-acls.sh"):
+            self.executable(name, command)
+        self.executable("sleep", "#!/bin/sh\nexit 0\n")
+        script = self.directory / "bootstrap.sh"
+        script.write_text((AUTOMQ / "scripts/bootstrap-cluster.sh").read_text()
+                          .replace("/opt/automq/kafka/bin", str(self.bin))
+                          .replace("/run/secrets", str(secrets)))
+        return script
+
+    def test_bootstrap_retries_api_before_mutating_cluster(self):
+        result = self.run_script(self.prepare_bootstrap(2))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        attempts = self.directory / "attempts"
+        self.assertTrue(attempts.exists(), "Bootstrap never probed the Kafka API")
+        self.assertEqual(attempts.read_text(), "3")
+        self.assertTrue((self.directory / "mutations").exists())
+
+    def test_bootstrap_fails_without_mutations_when_api_never_ready(self):
+        result = self.run_script(self.prepare_bootstrap(1000))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.directory / "mutations").exists())
+
+
+class HealthTests(ShellFixture):
+    def test_health_requires_partition_rows_and_every_leader(self):
+        self.executable("kafka-broker-api-versions.sh", "#!/bin/sh\nexit 0\n")
+        self.executable("kafka-topics.sh", '#!/bin/sh\nprintf "%s\\n" "$TOPIC_DESCRIPTION"\n')
+        script = self.directory / "health.sh"
+        script.write_text((AUTOMQ / "scripts/healthcheck-kafka.sh").read_text()
+                          .replace("/opt/automq/kafka/bin", str(self.bin)))
+        self.env.update(VVG_TOPIC="vvg.logs.v1", GATEWAY_TOPIC="gateway.access.v1")
+        for description, healthy in [
+            ("", False),
+            ("Topic: vvg.logs.v1 PartitionCount: 1 ReplicationFactor: 1", False),
+            ("Topic: vvg.logs.v1 Partition: 0 Leader: -1 Replicas: 0 Isr:", False),
+            ("Topic: vvg.logs.v1 Partition: 0 Leader: none Replicas: 0 Isr:", False),
+            ("Topic: vvg.logs.v1 Partition: 0 Leader: 0 Replicas: 0 Isr: 0", True),
+            ("Topic: vvg.logs.v1 Partition: 0 Leader: 0 Replicas: 0 Isr: 0\n"
+             "Topic: vvg.logs.v1 Partition: 1 Leader: -1 Replicas: 0 Isr:", False),
+        ]:
+            with self.subTest(description=description):
+                self.env["TOPIC_DESCRIPTION"] = description
+                self.assertEqual(self.run_script(script).returncode == 0, healthy)
+
+
+class WatchdogTests(ShellFixture):
+    def setUp(self):
+        super().setUp()
+        self.env["AUTOMQ_DIR"] = str(self.directory)
+        (self.directory / ".env").write_text(
+            "VVG_CONSUMER_GROUP=vvg-victorialogs-shadow-v1\n"
+            "GATEWAY_CONSUMER_GROUP=gateway-clickhouse-shadow-v1\n"
+        )
+        self.scenario = {"healthy": True, "services": {
+            "vector-gateway-production": ["gateway-1"],
+            "vector-vvg-production": ["vvg-1", "vvg-2"]}, "groups": {}}
+        self.executable("docker", '''#!/usr/bin/env python3
+import json, os, pathlib, sys
+root = pathlib.Path(os.environ["FIXTURE"])
+state = json.loads((root / "scenario.json").read_text())
+args = sys.argv[1:]
+if args[0] == "inspect":
+    print("healthy" if state["healthy"] else "unhealthy")
+elif args[0] == "ps":
+    service = next(a.split("=", 2)[-1] for a in args if a.startswith("label=com.docker.compose.service="))
+    ids = state["services"].get(service, [])
+    if "label=com.docker.compose.project=automq" not in args:
+        ids = ids + state.get("foreign_services", {}).get(service, [])
+    print("\\n".join(ids))
+elif args[0] == "exec":
+    group = args[args.index("--group") + 1]
+    with (root / "queries").open("a") as stream:
+        stream.write(group + "\\n")
+    value = state["groups"].get(group, "empty")
+    if value == "error":
+        sys.exit(1)
+    if value == "malformed":
+        print("unexpected output")
+    elif "--state" in args:
+        print("\\nGROUP COORDINATOR (ID) ASSIGNMENT-STRATEGY STATE #MEMBERS")
+        print(group + " automq:19092 (0) range " + ("Stable 2" if value == "active" else "Empty 0"))
+    else:
+        print("\\nGROUP TOPIC PARTITION CURRENT-OFFSET LOG-END-OFFSET LAG CONSUMER-ID HOST CLIENT-ID")
+        print(group + " vvg.logs.v1 0 10 10 0 " + ("member /host vector" if value == "active" else "- - -"))
+elif args[0] == "restart":
+    with (root / "restarts").open("a") as stream:
+        stream.write(args[-1] + "\\n")
+else:
+    sys.exit(2)
+''')
+
+    def tick(self):
+        (self.directory / "scenario.json").write_text(json.dumps(self.scenario))
+        result = self.run_script(AUTOMQ / "scripts/consumer-watchdog.sh")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def restarted(self):
+        path = self.directory / "restarts"
+        return sorted(path.read_text().splitlines()) if path.exists() else []
+
+    def test_restart_only_after_two_successful_empty_observations(self):
+        self.tick()
+        self.assertEqual(self.restarted(), [])
+        self.tick()
+        self.assertEqual(self.restarted(), ["gateway-1", "vvg-1", "vvg-2"])
+
+    def test_query_error_does_not_block_other_group_recovery(self):
+        self.scenario["groups"]["gateway-clickhouse-production-v1"] = "error"
+        self.tick()
+        self.tick()
+        self.assertEqual(self.restarted(), ["vvg-1", "vvg-2"])
+
+    def test_unknown_or_broker_down_breaks_consecutive_failure_count(self):
+        for interruption in ("error", "malformed", "broker-down"):
+            with self.subTest(interruption=interruption):
+                self.scenario["groups"] = {}
+                self.tick()
+                if interruption == "broker-down":
+                    self.scenario["healthy"] = False
+                else:
+                    self.scenario["groups"] = {group: interruption for group in
+                        ("gateway-clickhouse-production-v1", "vvg-victorialogs-production-v1")}
+                self.tick()
+                self.scenario["healthy"] = True
+                self.scenario["groups"] = {}
+                self.tick()
+                self.assertEqual(self.restarted(), [])
+                self.scenario["groups"] = {group: "active" for group in
+                    ("gateway-clickhouse-production-v1", "vvg-victorialogs-production-v1")}
+                self.tick()
+
+    def test_other_compose_project_does_not_hide_local_shadow(self):
+        self.scenario["services"] = {"vector-vvg-shadow": ["shadow-1"]}
+        self.scenario["foreign_services"] = {"vector-vvg-production": ["foreign-1"]}
+        self.tick()
+        self.tick()
+        self.assertEqual(self.restarted(), ["shadow-1"])
+
+    def test_dotenv_is_data_and_never_executes_shell(self):
+        marker = self.directory / "must-not-exist"
+        with (self.directory / ".env").open("a") as stream:
+            stream.write(f"UNRELATED_VALUE=$(touch {marker})\n")
+        self.tick()
+        self.assertFalse(marker.exists(), "watchdog executed .env as shell code")
+
+
+class ManifestTests(unittest.TestCase):
+    def config(self):
+        docs = yaml.safe_load_all((ROOT / "k8s-deployment/vector/vvg/direct-containerd.yaml").read_text())
+        return yaml.safe_load(next(d for d in docs if d.get("kind") == "ConfigMap")["data"]["vector.yaml"])
+
+    def test_vvg_preserves_live_sink_inputs_and_auxiliary_sinks(self):
+        config = self.config()
+        config["transforms"]["site_redaction"] = {
+            "type": "remap", "inputs": ["add_msg_field"], "source": "del(.token)"}
+        config["sinks"]["victorialogs"]["inputs"] = ["site_redaction"]
+        config["sinks"]["site_diagnostics"] = {
+            "type": "blackhole", "inputs": ["site_redaction"]}
+        for mode in ("shadow", "production"):
+            with self.subTest(mode=mode):
+                output = yaml.safe_load(renderer.render_vector_config(yaml.safe_dump(config), "vvg", mode))
+                self.assertEqual(output["transforms"]["prepare_automq_event"]["inputs"], ["site_redaction"])
+                self.assertEqual(output["sinks"]["site_diagnostics"], config["sinks"]["site_diagnostics"])
+
+    def test_vvg_rejects_missing_live_sink_inputs(self):
+        config = self.config()
+        config["sinks"]["victorialogs"]["inputs"] = []
+        with self.assertRaises(SystemExit):
+            renderer.render_vector_config(yaml.safe_dump(config), "vvg", "production")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-automq.sh
+++ b/scripts/validate-automq.sh
@@ -207,8 +207,11 @@ PY
   else
     fail "Consumer watchdog must check Gateway before VVG"
   fi
-  require_literal "${root}/scripts/healthcheck-kafka.sh" "! grep -Eq 'Leader: (-1|none)'" \
-    "Broker health requires both business topics to have leaders"
+  if PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/tests -v; then
+    pass "AutoMQ startup, recovery and manifest behavior regressions pass"
+  else
+    fail "AutoMQ behavior regressions failed"
+  fi
   require_literal "${compose}" 'start_period: 5m' \
     "Broker health allows combined KRaft to recover topic leaders"
   require_literal "${root}/config/automq-consumer-watchdog.timer" 'OnUnitActiveSec=30s' \
@@ -471,11 +474,23 @@ validate_runtime() {
   }
   temp_dir="$(mktemp -d)"
   trap 'rm -rf -- "${temp_dir}"' RETURN
+  mkdir -p "${temp_dir}/producer-secrets"
+  printf 'validation-user' > "${temp_dir}/producer-secrets/username"
+  printf 'validation-password' > "${temp_dir}/producer-secrets/password"
   for pipeline in vvg gateway; do
     if [[ "${pipeline}" == vvg ]]; then
       source_manifest="k8s-deployment/vector/vvg/direct-containerd.yaml"
     else
       source_manifest="k8s-deployment/vector/gateway/direct-containerd.yaml"
+      local geoip_path expected_geoip
+      geoip_path="${GATEWAY_GEOIP_MMDB:-${temp_dir}/dbip-city-lite-2026-09.mmdb}"
+      expected_geoip="05a10861259c7966cb54d7181ef8c360de8c8829d182098c0e62a9b7d54cd50d"
+      if [[ ! -f "${geoip_path}" ]]; then
+        curl -L --fail --retry 5 --retry-all-errors --connect-timeout 30 --max-time 900 \
+          -o "${geoip_path}" \
+          https://github.com/seaworld008/vvg-logs-system/releases/download/geoip-dbip-city-lite-2026-09/dbip-city-lite-2026-09.mmdb
+      fi
+      echo "${expected_geoip}  ${geoip_path}" | sha256sum -c -
     fi
     for rollout_mode in shadow production; do
       rendered="${temp_dir}/${pipeline}-${rollout_mode}.yaml"
@@ -538,7 +553,32 @@ else:
             for volume in ds["spec"]["template"]["spec"]["volumes"]
         )
 print(f"PASS: rendered {pipeline} {mode} producer manifest")
+with open(path + ".vector.yaml", "w", encoding="utf-8") as output:
+    output.write(configmaps[0]["data"]["vector.yaml"])
 PY
+      local -a geoip_mounts=()
+      if [[ "${pipeline}" == gateway ]]; then
+        geoip_mounts=(
+          -v "${geoip_path}:/var/lib/vector/geoip/dbip-city-lite-2026-09.mmdb:ro"
+          -v "${geoip_path}:/var/lib/vector-geoip/geoip/dbip-city-lite-2026-09.mmdb:ro"
+        )
+      fi
+      docker run --rm \
+        -e VLS_ENDPOINT=http://victorialogs.example:9428 \
+        -e VLS_TENANT_ID=99:99 \
+        -e VECTOR_SELF_NODE_NAME=validation-node \
+        -e HOSTNAME=validation-node \
+        -e VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true \
+        -e AUTOMQ_BOOTSTRAP_SERVERS=automq.example:9092 \
+        -e "AUTOMQ_TOPIC=${pipeline}.validation" \
+        -e "AUTOMQ_PRODUCER_USERNAME=${pipeline}-producer" \
+        -v "${rendered}.vector.yaml:/etc/vector/vector.yaml:ro" \
+        -v "${temp_dir}/producer-secrets:/var/run/secrets/automq:ro" \
+        -v "${temp_dir}/producer-secrets:/var/run/secrets/clickhouse:ro" \
+        "${geoip_mounts[@]}" \
+        timberio/vector:0.58.0-alpine \
+        validate --no-environment /etc/vector/vector.yaml
+      pass "Rendered ${pipeline} ${rollout_mode} producer compiles with Vector 0.58.0"
     done
   done
   rm -rf -- "${temp_dir}"


### PR DESCRIPTION
本次仓库检查发现，AutoMQ 首次启动存在 Topic-aware health 与 bootstrap 相互等待的问题；watchdog 的查询错误会阻断另一条链路恢复，且 VVG producer 生成器会绕过现场追加的转换。

变更：
- bootstrap 等待有界的已认证 Kafka API，消费者保留 bootstrap 成功和 Topic leader 健康双门禁；健康检查拒绝无分区输出并校正超时预算。
- watchdog 使用 group state 判断成员数，隔离查询失败、清除不连续计数、限定本机 Compose project，并将 .env 作为数据读取。
- VVG 生产者继承现场 sink inputs 并保留辅助 sink；远端消费者禁止启动时在线拉取镜像。
- 新增 12 项行为回归测试，并在运行时校验中实际编译 VVG/Gateway 的 shadow/production 四种生成配置。
- 同步运行手册及 docs/repository-audit-2026-09-05.md，记录其他优化项与生产验证边界。

验证：
- 12 项新增测试全部通过，缺陷用例已先在原代码上复现失败。
- 全仓库静态校验、生成资产防漂移、9 个 JSON/23 个 YAML/15 个 shell 语法检查及 git diff --check 通过。
- 独立代码复审无阻断问题；完整 Docker/Vector CI 必须通过后再合并。

本次没有访问或部署生产主机，没有批量升级镜像、插件或修改业务表结构。合并后按用户要求清理已核实合并的旧分支，保留 main。