### PR TITLE
fix: 限制 producer 内存排队并补齐 Broker 重建恢复验收

### DIFF
--- a/docs/shared-host-load-runbook.md
+++ b/docs/shared-host-load-runbook.md
@@ -94,6 +94,48 @@ docker exec automq bash -c '
 Broker 不可达时清除历史且不重启 producer。指标无法读取或解析时不伪造零队列。
 Prometheus 文本解析兼容带 timestamp 和不带 timestamp 的样本。
 
+producer 除了磁盘 buffer，还有 librdkafka 内存队列。两个 lane 各允许 256 MiB 时，
+内存排队上限合计达到 512 MiB，尚未计入编码副本、压缩、source 和其他转换状态。
+Broker 断连时曾触发 2 GB producer 的 OOM。当前每个 Kafka sink 将
+`queue.buffering.max.kbytes` 限为 `65536`，双 lane 合计 128 MiB；继续保留总计 10 GiB
+disk/block、无限重试、ack、Zstd 和原批次。该调整限制驻留排队，不是吞吐限速；
+上线后仍需比较正常吞吐、恢复追赶速率和内存峰值，不能据此宣称绝不 OOM。
+
+## Broker 重建的恢复门禁
+
+重建已有 Broker 验证的是持久状态恢复，不等于空 Topic/空 KRaft 的首次部署验证。
+计划重建时备份配置、消费 offset 和容器基线，优雅停止后保存一致性 KRaft metadata，
+再用原精确镜像 `up -d --no-deps --force-recreate automq`。不执行空数据初始化，
+不删除 Topic、offset、OBS 或 producer checkpoint。
+
+Vector 0.58 客户端在 Broker 重建后曾停留在失效的 coordinator/leader 会话。必须分层
+验证，不能把 Broker healthy、consumer group Stable、有成员或 consumer 自报 lag=0
+当作全链路恢复。用认证后的 Kafka CLI 查询每个 production group 的 committed offset
+与 log end offset，并核对后端最新事件时间：
+
+```bash
+docker exec \
+  -e KAFKA_HEAP_OPTS='-Xms32m -Xmx128m' \
+  -e KAFKA_JVM_PERFORMANCE_OPTS='-XX:+UseSerialGC -XX:ActiveProcessorCount=1' \
+  automq timeout 20 /opt/automq/kafka/bin/kafka-consumer-groups.sh \
+  --bootstrap-server localhost:19092 \
+  --command-config /etc/automq/admin-client.properties \
+  --describe --group PRODUCTION_GROUP
+```
+
+Broker healthy 后若真实 lag 上升、committed offset 不动且后端时间不推进，按现场
+所有权恢复对应消费者。远端三个 VVG 实例不属于 Broker 主机的本地 watchdog：在其
+目标主机执行 `docker restart -t 120`；同组全部确认停滞时可并行优雅重启，避免逐个
+等待导致恢复窗口叠加。只恢复必要实例，检查 group 重平衡、offset 继续推进、lag 回落
+及下游最新时间。`AssignmentLost` 可能使已处理而未提交的消息重放，不能把重放
+误判为新流量，也不能仅凭 drop counter 没增长承诺整个 source 边界绝无丢失。
+
+producer liveness 仍保留低速停滞恢复。等待 120 秒优雅退出时，metrics/readiness
+可能暂时不可用；不要在原恢复尚未结束时叠加删除 Pod、复制活动 disk buffer 或多次重启。
+出现 OOM 时必须记录，而不能把自动重启后的 Running 状态描述成“全程零 OOM”。
+当前版本的 consumer 自动恢复仍有此边界，本地 Empty-group watchdog 不覆盖远端
+Stable-but-stalled group；计划维护必须包含上述主动恢复和验收步骤。
+
 ## 发布与验收
 
 先核对仓库修复是否已经进入现场活动配置。拉取最新 Git 不会自动更新服务器：检查
@@ -143,3 +185,4 @@ git diff --check
 [Kafka TopicCommand](https://github.com/apache/kafka/blob/3.9.1/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java)、
 [Kafka consumer group 协议回退](https://github.com/apache/kafka/blob/3.9.1/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandler.java)、
 [Vector Prometheus exporter](https://vector.dev/docs/reference/configuration/sinks/prometheus_exporter/)。
+producer 内存队列语义见 [librdkafka 配置](https://github.com/confluentinc/librdkafka/blob/v2.10.1/CONFIGURATION.md)。

--- a/k8s-deployment/vector/gateway/automq-containerd-production.yaml
+++ b/k8s-deployment/vector/gateway/automq-containerd-production.yaml
@@ -268,7 +268,7 @@ data:
           enable.idempotence: 'true'
           max.in.flight.requests.per.connection: '5'
           message.max.bytes: '4194304'
-          queue.buffering.max.kbytes: '262144'
+          queue.buffering.max.kbytes: '65536'
           linger.ms: '100'
           metadata.max.age.ms: '60000'
           metadata.recovery.strategy: rebootstrap
@@ -396,7 +396,7 @@ spec:
       labels:
         app: vector-clickhouse-gateway
       annotations:
-        logs.example.com/vector-config-sha256: db00c0783bee25818301531477d716f355f88b6c7e9b98b9d128f39a9a528553
+        logs.example.com/vector-config-sha256: 838628de7c53e3dd622ade66947acb5da6dba5f6c952c010463b00d98dbbdadd
         logs.example.com/automq-mode: production
     spec:
       automountServiceAccountToken: false

--- a/k8s-deployment/vector/vvg/automq-containerd-production.yaml
+++ b/k8s-deployment/vector/vvg/automq-containerd-production.yaml
@@ -165,7 +165,7 @@ data:
           enable.idempotence: 'true'
           max.in.flight.requests.per.connection: '5'
           message.max.bytes: '4194304'
-          queue.buffering.max.kbytes: '262144'
+          queue.buffering.max.kbytes: '65536'
           linger.ms: '100'
           metadata.max.age.ms: '60000'
           metadata.recovery.strategy: rebootstrap
@@ -209,7 +209,7 @@ data:
           enable.idempotence: 'true'
           max.in.flight.requests.per.connection: '5'
           message.max.bytes: '4194304'
-          queue.buffering.max.kbytes: '262144'
+          queue.buffering.max.kbytes: '65536'
           linger.ms: '100'
           metadata.max.age.ms: '60000'
           metadata.recovery.strategy: rebootstrap
@@ -368,7 +368,7 @@ spec:
       labels:
         app: vector
       annotations:
-        logs.example.com/vector-config-sha256: 3d4ca6bd453668f0ceae1414b158637f8476171e0b7ee247af88f4d3a51b5ac8
+        logs.example.com/vector-config-sha256: 654ea841c321972066bf432ed5696bec727dfe9c78422c984877c6430acc6340
         logs.example.com/automq-mode: production
     spec:
       terminationGracePeriodSeconds: 120

--- a/scripts/render-automq-vector-manifest.py
+++ b/scripts/render-automq-vector-manifest.py
@@ -154,7 +154,7 @@ def kafka_sink(inputs: list[str], buffer_size: int) -> dict[str, Any]:
             "enable.idempotence": "true",
             "max.in.flight.requests.per.connection": "5",
             "message.max.bytes": "4194304",
-            "queue.buffering.max.kbytes": "262144",
+            "queue.buffering.max.kbytes": "65536",
             "linger.ms": "100",
             "metadata.max.age.ms": "60000",
             "metadata.recovery.strategy": "rebootstrap",

--- a/scripts/tests/test_automq_reliability.py
+++ b/scripts/tests/test_automq_reliability.py
@@ -329,6 +329,14 @@ class ProducerProgressTests(ShellFixture):
 
 
 class ManifestTests(unittest.TestCase):
+    def test_native_producer_queues_are_bounded_behind_disk_backpressure(self):
+        sink = renderer.kafka_sink(["events"], 5368709120)
+        self.assertEqual(sink["librdkafka_options"]["queue.buffering.max.kbytes"], "65536")
+        self.assertEqual(sink["buffer"], {"type": "disk", "max_size": 5368709120, "when_full": "block"})
+        self.assertEqual(sink["message_timeout_ms"], 0)
+        self.assertEqual(sink["librdkafka_options"]["acks"], "all")
+        self.assertEqual(sink["compression"], "zstd")
+
     def config(self):
         docs = yaml.safe_load_all((ROOT / "k8s-deployment/vector/vvg/direct-containerd.yaml").read_text())
         return yaml.safe_load(next(d for d in docs if d.get("kind") == "ConfigMap")["data"]["vector.yaml"])


### PR DESCRIPTION
Broker 原镜像重建实测暴露了 Vector 客户端的恢复边界：producer 在断连积压期间触发 OOM，consumer 可能保留 Stable 成员状态但停止拉取，其自报 lag=0 与 Kafka 管理接口的真实 offset 不一致。恢复消费者后积压回落，后端最新日志恢复推进。

将每个 Kafka producer 的 librdkafka 内存队列上限由 256 MiB 收紧到 64 MiB，减少双 lane 断连时的驻留排队；保留磁盘 buffer、block、无限重试、ack、Zstd、批次及容器资源。生成清单同步，并补充原镜像重建、一致性 metadata 备份、真实 offset 验收、consumer 显式恢复和 OOM 如实记录的运行手册。

验证：20 项回归测试通过；全仓库静态与生成清单防漂移通过；现场候选由当前活动 manifest 生成，结构化确认只改 native queue 上限和配置 hash，并通过 Vector 0.58 实际编译。生产只滚动 VVG producer，Gateway 通用模板随生成器同步，未滚动生产 Gateway 配置。完整容器校验由 CI 执行。

本次不宣称修复了 Vector/librdkafka 的全部自动重连问题，也不把 Broker healthy 等同于全链路恢复。consumer Stable-but-stalled 仍需运行手册中的主动恢复；没有再次执行生产 Broker 故障注入来证明新队列配置绝不 OOM。真实地址、凭据和原始运行数据不入 Git。
