### PR TITLE
feat: support metrics push for restricted host log routes

### DIFF
--- a/docker-compose/vector/host-automq/README.md
+++ b/docker-compose/vector/host-automq/README.md
@@ -117,6 +117,12 @@ IdempotentWrite；消费者只获该 Topic 的 Read/Describe 和固定 group 的
 Kafka committed/end offset 的真实 lag、消费者内存、磁盘余量和后端最新业务时间。
 维护 Broker 后必须核对真实 offset 和后端新日志，不仅查看容器 Running。
 
+跨网段不允许中心拉取指标时，可在 inventory 设置 `metrics.mode: push`，并在 `.env`
+配置组织既有的 `METRICS_REMOTE_WRITE_URL`。Vector 每 15 秒通过 Prometheus Remote Write
+主动上报，使用有界独立 memory 队列，不改变日志的 Kafka disk buffer，也不增加消费者。
+按需设置 `metrics.instance/ident` 与已有主机监控身份对齐；中心删除这些主机重复且不可达
+的 scrape target。检查主动上报序列的时间新鲜度，不能把不再执行的拉取检查当作主机 down。
+
 ## 校验与回滚
 
 ```bash

--- a/scripts/render-host-log-collector.py
+++ b/scripts/render-host-log-collector.py
@@ -98,6 +98,20 @@ def render(spec, initial=False):
     cfg['transforms']['normalize']['inputs'] = ['identify_'+sid for sid in sorted(known)]
     compose = yaml.safe_load((ROOT / 'docker-compose/vector/host-automq/compose.yaml').read_text(encoding='utf-8'))
     compose['services']['vector']['volumes'] += [f'{m}:{m}:ro' for m in sorted(mounts)]
+    metrics=spec.get('metrics',{})
+    if metrics.get('mode')=='push':
+        cfg['sources']['internal_metrics']['scrape_interval_secs']=15
+        tags={'project':route['project'],'environment':route['environment'],'pipeline':'host-vvg',
+              'job':'vector-host-logs','instance':metrics.get('instance',spec['hostname']),
+              'ident':metrics.get('ident',spec['hostname']),'transport':'push'}
+        cfg['transforms']['tag_exported_metrics']={'type':'remap','inputs':['internal_metrics'],
+            'source':'\n'.join('.tags.'+key+' = '+json.dumps(value) for key,value in tags.items())+'\n'}
+        cfg['sinks']['metrics_remote_write']={'type':'prometheus_remote_write','inputs':['tag_exported_metrics'],
+            'endpoint':'${METRICS_REMOTE_WRITE_URL}','healthcheck':False,
+            'batch':{'max_events':1000,'timeout_secs':1},
+            'buffer':{'type':'memory','max_events':1000,'when_full':'block'},
+            'request':{'concurrency':1,'timeout_secs':10}}
+        compose['services']['vector']['environment']['METRICS_REMOTE_WRITE_URL']='${METRICS_REMOTE_WRITE_URL}'
     return cfg, compose
 
 

--- a/scripts/tests/test_host_log_collector.py
+++ b/scripts/tests/test_host_log_collector.py
@@ -52,5 +52,15 @@ class HostCollectorTest(unittest.TestCase):
         host={'files':[{'legacy_index':'java_prod_order'},{'legacy_index':'php_jxgl_log'}]}
         with self.assertRaises(ValueError): renderer.route_for(host)
 
+    def test_metrics_push_does_not_change_log_transport(self):
+        host={'hostname':'node-01','metrics':{'mode':'push'},'files':[{'id':'api','service':'api','format':'java',
+              'legacy_index':'java_api','include':['/data/apps/api/logs/*.log'],'mounts':['/data/apps/api/logs']}]}
+        cfg,compose=renderer.render(host)
+        self.assertEqual(cfg['sinks']['automq']['inputs'],['drop_formatting_noise'])
+        self.assertEqual(cfg['sources']['internal_metrics']['scrape_interval_secs'],15)
+        self.assertEqual(cfg['sinks']['metrics_remote_write']['buffer']['type'],'memory')
+        self.assertEqual(cfg['sinks']['metrics_remote_write']['request']['concurrency'],1)
+        self.assertIn('METRICS_REMOTE_WRITE_URL',compose['services']['vector']['environment'])
+
 
 if __name__ == '__main__': unittest.main()


### PR DESCRIPTION
Allow host collectors to push their internal metrics to an existing Prometheus Remote Write receiver when central scraping is blocked across network boundaries. This reuses the Vector Compose deployment, samples every 15 seconds, and keeps a bounded independent metrics queue without changing the Kafka log route or adding consumers.

Document the push-mode inventory settings and removal of redundant pull targets. Validation includes generator regression tests, actual Vector configuration validation, and fresh incoming metric series at the existing receiver.
