### PR TITLE
docs: unify legacy PHP backend and API log service names

### DIFF
--- a/docker-compose/vector/host-automq/README.md
+++ b/docker-compose/vector/host-automq/README.md
@@ -21,6 +21,9 @@ Java / PHP 文件 -> Vector file source -> logs.<环境>.<项目>.v1 -> 项目 c
 | 其他 Java / PHP | `wangda-app` | 网大APP |
 
 `php_jxgl-pay-and-more_log*` 不属于两个例外。不要用宽泛 `jxgl*` 规则替代。
+老教务后台和 API 统一使用 `php_jxgl`；莆田后台和 API 统一使用 `php_jxgl-ptlndx`。
+后台参考 `legacy-admin.inventory.example.yaml`，共享 API 日志参考
+`legacy-api.inventory.example.yaml`。同一 NFS 文件只采集一次，不能把采集主机标签当作写入实例。
 `container` 是服务名，`pod` 是稳定主机名，`namespace` 是 `java/php/text` 类型；
 `file` 和 `source_offset` 保留排查定位。业务事件不能覆盖生成器指定的项目标签。
 

--- a/docker-compose/vector/host-automq/legacy-admin.inventory.example.yaml
+++ b/docker-compose/vector/host-automq/legacy-admin.inventory.example.yaml
@@ -1,0 +1,13 @@
+project: legacy-php
+environment: prod
+hostname: legacy-admin-01
+files:
+  - id: jxgl
+    service: jxgl
+    format: php
+    legacy_index: php_jxgl_log
+    include:
+      - /data/apps/legacy-admin/runtime/log/**/*.log
+      - /data/apps/legacy-admin/runtime/log/**/*.jsonl
+      - /data/apps/legacy-admin/runtime/log/**/*.ndjson
+    mounts: [/data/apps/legacy-admin/runtime/log]

--- a/docker-compose/vector/host-automq/legacy-api.inventory.example.yaml
+++ b/docker-compose/vector/host-automq/legacy-api.inventory.example.yaml
@@ -1,0 +1,22 @@
+project: legacy-php
+environment: prod
+hostname: legacy-api-log-owner
+files:
+  - id: jxgl
+    service: jxgl
+    format: php
+    legacy_index: php_jxgl_log
+    include:
+      - /data/apps/legacy-api/runtime/log/**/*.log
+      - /data/apps/legacy-api/runtime/log/**/*.jsonl
+      - /data/apps/legacy-api/runtime/log/**/*.ndjson
+    mounts: [/data/apps/legacy-api/runtime/log]
+  - id: jxgl_ptlndx
+    service: jxgl-ptlndx
+    format: php
+    legacy_index: jxgl-ptlndx
+    include:
+      - /data/apps/putian/runtime/log/**/*.log
+      - /data/apps/putian/runtime/log/**/*.jsonl
+      - /data/apps/putian/runtime/log/**/*.ndjson
+    mounts: [/data/apps/putian/runtime/log]

--- a/docs/host-log-format-rules.md
+++ b/docs/host-log-format-rules.md
@@ -29,8 +29,20 @@
 
 ## 目录与服务
 
-PHP 的 `service` 和兼容 `container` 统一以 `php_` 开头，例如 `php_jxgl`、
-`php_jxgl-ptlndx`、`php_activityadmin`。Java 服务名不添加该前缀。
+PHP 的 `service` 和兼容 `container` 统一以 `php_` 开头。老教务后台和教务 API
+统一使用 `php_jxgl`；莆田后台和 API 统一使用 `php_jxgl-ptlndx`，不按 admin/api 拆分。
+网大后台例如 `php_activityadmin`。Java 服务名不添加该前缀。
+
+后台和 API 都属于 `legacy-php`，共用 `logs.prod.legacy-php.v1` 以及该项目的一个消费者。
+参考 `legacy-admin.inventory.example.yaml` 和 `legacy-api.inventory.example.yaml`。
+服务显示名调整时保留原 source ID、include、fingerprint、state 和 checkpoint，
+不能为改名重新从头读取文件。历史日志保留旧标签，新日志使用新服务名。
+
+共享日志目录只由一个指定采集端读取。例如 API 的多台主机通过 NFS 写入同一份
+runtime/log，应该在共享目录所有者处采集一次；不能在每个 NFS 客户端重复部署相同
+采集。此时 `instance/pod` 表示采集主机，不能冒充实际写入容器。莆田后台和 API
+共用文件时统一标为 `php_jxgl-ptlndx`；精确区分写入实例需要应用增加身份字段或使用
+独立日志目录。Nginx access/error 日志不包含在这些应用日志清单中。
 
 每个已经确认的日志根目录使用递归模式：
 


### PR DESCRIPTION
Document a unified service identity for legacy PHP backends and APIs: `php_jxgl` for the education system and `php_jxgl-ptlndx` for the Putian application. Both remain in `legacy-php` with the existing topic and single consumer; do not split admin/API service names.

Add sanitized deployment inventory examples and explain single-owner collection for shared NFS logs. Collector host labels identify the reader, not the originating application replica. Nginx logs remain outside these inventories.

Validation: both inventories render successfully; live Vector configurations validate; existing checkpoint hashes remained unchanged during the label correction; writes from a second application host were collected exactly once through the shared-file collector with the expected unified labels and exact message content.
