### PR TITLE
docs: 沉淀多项目主机日志迁移与原生 Filters 经验

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,18 @@ Vector位于 `k8s-deployment/vector/gateway/`，Grafana可选配置位于
 - 四条 production链路由 `docs/log-pipeline-selection.md` 统一索引；直写清单是源，仓库 AutoMQ清单必须由 `scripts/render-automq-example-manifests.py` 生成并通过防漂移检查。
 - 本阶段不得停止或重建 `redis-v9`、`elk_redis`、Logstash、Kibana、Elasticsearch、VictoriaLogs、ClickHouse、Grafana或业务服务。
 
+## 主机 Java/PHP 迁移专区
+
+任务先读 `docker-compose/vector/host-automq/README.md`、`docs/host-log-format-rules.md`、
+`docs/log-project-naming-and-labels.md` 和 `docs/host-log-migration-lessons.md`。
+
+- Topic、group 和身份按项目隔离；网大APP和老教务PHP各一个消费者，不按服务拆分。
+- PHP 服务以 `php_` 开头；老教务后台/API 统一 `php_jxgl`，莆田后台/API 统一 `php_jxgl-ptlndx`。
+- runtime 先盘点用途，再递归采集确认的日志根目录；共享 NFS 文件指定一个采集所有者，禁止把缓存、会话或业务账号列表当日志。
+- `message` 在 Kafka 中是唯一正文；消费者转为 `_msg`，明细查询临时复制 `message`。不能只凭入库条数证明正文可搜索。
+- 首次 EOF 初始化只在采集器停止且明确接受丢失的迁移窗口执行；日常升级保留 source ID、fingerprint 和 state，禁止重置 checkpoint。
+- 本路线不修改 CCE 采集或 Nginx 日志，不顺带退役旧 ELK、Redis 和历史数据。
+
 ## Dashboard 修改
 
 `scripts/render-vvg-message-filter.mjs` 是 message 多条件面板和紧凑布局的源。不要分别手改面板模板与 Dashboard：
@@ -93,6 +105,10 @@ bash scripts/validate-clickhouse-gateway.sh --static
 ```
 
 多条件值只能由经过测试的构造函数生成 LogsQL，再通过 `${message_filter_expr:raw}` 插入。用户输入不得直接 raw 插值。编辑、添加、删除和切换 AND/OR 不得触发查询；只有 Apply 和 Reset 可以更新 Dashboard 变量。
+
+原生 `Filters` 是独立的可见 ad hoc 变量，固定绑定 `victorialogs-ds`，默认条件为空、URL 同步开启。
+清空后仍须显示，与日志详情加减号使用同一控件；不要复制自定义字段面板或再向查询拼接 raw 条件。
+仅更新 Dashboard 定义不重启 Grafana；验收字段条件同时影响明细、统计和 hits 趋势，并恢复零条件。
 
 ## 插件发布
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ VVG 直写基线位于 `k8s-deployment/vector/vvg/direct-containerd.yaml`，Gate
 - [日志链路选型与 Kubernetes 快速启用指南](docs/log-pipeline-selection.md)
 - [Compose 主机 Java/PHP 日志迁移与 AutoMQ 采集](docker-compose/vector/host-automq/README.md)
 - [多项目 Topic 命名、标签与权限规范](docs/log-project-naming-and-labels.md)
+- [网大APP、老教务PHP迁移与原生 Filters 实践](docs/host-log-migration-lessons.md)
+- [v0.7.0 发布说明](docs/releases/v0.7.0.md)
 
 ## VVG 核心架构
 

--- a/docker-compose/vector/host-automq/README.md
+++ b/docker-compose/vector/host-automq/README.md
@@ -12,6 +12,7 @@ Java / PHP 文件 -> Vector file source -> logs.<环境>.<项目>.v1 -> 项目 c
 
 完整命名、分区、账号及标签约定见[日志项目规范](../../../docs/log-project-naming-and-labels.md)。
 原始格式、业务多行边界与目录排除见[主机日志格式规则](../../../docs/host-log-format-rules.md)。
+迁移验收、旧环境兼容和常见误判见[主机迁移与 Filters 实践](../../../docs/host-log-migration-lessons.md)。
 源清单明确记录旧索引、服务、文件路径、只读挂载和稳定 source ID。分类由
 `scripts/render-host-log-collector.py` 统一生成：
 
@@ -44,10 +45,10 @@ Java / PHP 文件 -> Vector file source -> logs.<环境>.<项目>.v1 -> 项目 c
   backups/
 ```
 
-消费者按项目使用独立目录和 Compose project，例如 `vector-wangda-app-consumer`，结构相同。若真实数据盘
-挂载在 `/datadisk`，可在该数据盘创建消费者目录，再通过 `/data/vector-host-consumer`
-软链接提供统一入口。正式项目消费者分别使用 `vector-wangda-app-consumer` 和
-`vector-legacy-php-consumer`，指标端口互不重叠。不要为了目录名称把新持久化放到空间不足的系统盘。
+消费者分别使用 `/data/vector-wangda-app-consumer/` 和 `/data/vector-legacy-php-consumer/`，
+Compose project 同样按项目独立，结构相同，指标端口互不重叠。若真实数据盘挂载在
+`/datadisk`，可在该数据盘分别创建目录，再以各自的 `/data/` 路径建立软链接。
+不要让两个消费者共用一个目录或 state，也不要为了目录名称把持久化放到空间不足的系统盘。
 
 正式镜像优先使用组织 Harbor 的精确 tag 与已验证 digest。启动前拉取并核对镜像 ID，
 正式启动不依赖在线下载。旧 Docker 或仓库 TLS/认证入口不兼容时，从受控发布主机
@@ -108,7 +109,7 @@ IdempotentWrite；消费者只获该 Topic 的 Read/Describe 和固定 group 的
 - 120 秒优雅停止；容器自身日志最多 `20 MiB x 3`。监控入口只绑定 loopback 或批准的内网。
 - Java/PHP 按日志头和 3 秒空闲超时合并，正常 9,000 行堆栈不按行数拆分。
 - 物理行超过 16 MiB 受 file source 上限约束。序列化正文超过 1,500,000 字节时显式
-  标记 `truncated`，保存原正文大小和脱敏正文摘要，并仅保留有界前段；不能宣称超大
+  标记 `truncated`，保存脱敏后、截断前的正文大小和摘要，并仅保留有界前段；不能宣称超大
   日志无损。截断不做采样，不影响其他正常事件。
 - Token、密码、认证头、手机号和身份证模式在 Kafka/OBS 持久化前脱敏。规则不能覆盖
   任意业务自定义秘密字段；新增格式时应补充测试并检查脱敏后样本。

--- a/docs/ai-agent-operations-guide.md
+++ b/docs/ai-agent-operations-guide.md
@@ -24,6 +24,7 @@
 | VVG/Gateway 持久缓冲 | `docker-compose/automq/README.md`、`docs/automq-log-buffer-runbook.md` |
 | 四条链路选型与完整 K8S YAML | `docs/log-pipeline-selection.md` |
 | 主机 Java/PHP Filebeat 迁移 | `docker-compose/vector/host-automq/README.md`、`scripts/render-host-log-collector.py` |
+| 多项目迁移经验、PHP 共享目录、正文与原生 Filters | `docs/host-log-migration-lessons.md` |
 | 共享宿主机负载与 producer 高峰误重启 | `docs/shared-host-load-runbook.md` |
 | Vector OOM、排队预算与 9000 行日志完整性 | `docs/vector-memory-and-recovery-runbook.md` |
 

--- a/docs/grafana-victorialogs-log-search-dashboard-guide.md
+++ b/docs/grafana-victorialogs-log-search-dashboard-guide.md
@@ -88,7 +88,8 @@ curl -fsS http://127.0.0.1:9428/select/logsql/stream_field_values \
 | 服务 | `service` | Query/Multi | All | `container` 字段值 |
 | Pod | `pod` | Query/Multi | All | `pod` 字段值 |
 | 级别 | `level` | Query/Multi | All | `level` 字段值 |
-| message | `_msg` | Text box | `*` | 用户输入，使用模糊搜索 |
+| message | `message` | Text box | `*` | 用户输入，通过 `_msg:$message` 搜索正文 |
+| Filters | `Filters` | Ad hoc | 空条件 | `victorialogs-ds` 字段，顶部常驻 |
 | message 多条件表达式 | `message_filter_expr` | 隐藏 Text box | `*` | Business Text 生成 |
 | message 表单状态 | `message_filter_state` | 隐藏 Text box | 空状态 | URL-safe JSON |
 

--- a/docs/host-log-migration-lessons.md
+++ b/docs/host-log-migration-lessons.md
@@ -1,0 +1,175 @@
+# 主机日志迁移与原生 Filters 实践
+
+本文沉淀 2026-09-07 网大APP、老教务系统 PHP 的迁移和检索经验，供后续接入项目复用。
+现场凭据、地址、完整清单、日志样本与运行快照不在仓库中；每次实施必须重新盘点。
+本文说明操作顺序和判断依据，具体配置以生成器、Compose 与以下专项手册为准。
+
+| 内容 | 配置与手册 |
+| --- | --- |
+| 部署、资源、首次切换及回滚 | [Compose 主机路线](../docker-compose/vector/host-automq/README.md) |
+| Topic、身份、正文与标签 | [日志项目规范](log-project-naming-and-labels.md) |
+| 原始格式、多行与目录边界 | [主机日志格式规则](host-log-format-rules.md) |
+| Filters、message、布局及验收 | [日志大屏指南](grafana-victorialogs-log-search-dashboard-guide.md) |
+| 内存、缓冲和恢复 | [Vector 内存与恢复手册](vector-memory-and-recovery-runbook.md) |
+
+## 1. 先把业务来源映射清楚
+
+以旧索引、Filebeat 启用配置、应用日志配置、容器挂载和真实文件共同建立来源表，
+至少检查一周的活跃来源以覆盖低频服务。每项记录项目、服务、日志根目录、格式、
+读取所有者、source ID 和旧采集状态。某个索引今天没有数据或 Redis list 为空，
+不能证明该来源已经废弃。无法连接的主机应标为未验证，不能计入已完成覆盖。
+
+本次保留以下业务决定：
+
+| 范围 | project | service |
+| --- | --- | --- |
+| 网大 Java 与其他 PHP 应用 | `wangda-app` | Java 保持原服务名，PHP 加 `php_` 前缀 |
+| 老教务后台及教务 API | `legacy-php` | 统一 `php_jxgl` |
+| 莆田后台及 API | `legacy-php` | 统一 `php_jxgl-ptlndx` |
+
+旧索引 `jxgl-ptlndx*` 和 `php_jxgl_log*` 是旧来源分类的两个例外，其他 PHP 归网大。
+新增 API 根据确认的业务归属显式配置；不要把 `jxgl*` 扩大成通用分类正则。
+后台和 API 不创建独立服务名。改服务标签时保留 source ID、fingerprint 和 state，
+历史记录的旧标签不回写。CCE 采集与 Nginx access/error 日志不在本次迁移范围。
+
+每个项目一个 Topic、一个消费者组和一个 Vector 消费者，多个服务用字段筛选。
+沿用 `logs.<environment>.<project>.v1`，后续增加服务不增加 Topic 或消费者。
+吞吐与恢复目标确有需要时再扩容；项目下拉框只用于检索，不提供租户访问隔离。
+
+## 2. runtime 全面盘点，按确认的日志根目录递归
+
+从应用配置和代码确认 runtime 下每个目录的用途，再为真实日志根目录配置
+`**/*.log`、`**/*.jsonl`、`**/*.ndjson`。同时验证根目录直属文件、日期子目录和更深
+层级。不要只覆盖当天目录，也不要把整个 runtime 作为文本日志来源。
+
+runtime 内可能包含 session、cache、临时文件和推送账号列表。曾遇到 `push/*.txt`
+实际保存收件账号的情况，只有检查写入函数后才能判定其用途。新增扩展名同样要先
+确认内容和生产方式；`.nfs*` 等临时文件不能仅凭出现位置新增为采集来源。
+
+检查容器 bind mount、宿主机挂载及 NFS 路径是否最终指向同一份文件。多个 API 实例
+共享 runtime 时，指定一个读取所有者，在另一写入端产生受控唯一标记并验证只入库
+一次。此时 `instance/pod` 表示读取主机；需要定位实际写入实例时，应用必须写入
+实例字段或分开文件，采集端不能凭共享文件推断。
+
+## 3. 正则必须来自真实日志边界
+
+先在受控临时目录按格式、文件和大小抽样，覆盖正常请求、异常、SQL、CLI、XML、
+嵌套数组、有效 JSON 和旧 Logback 非法 JSON 包装。只将脱敏后的同结构合成样本
+加入回归，生产正文不得进入测试仓库。
+
+Java 按完整日志头合并堆栈；ThinkPHP 按请求头、下一边界和空闲超时合并请求块。
+无关联 ID 的独立输出不能强行拼成同一请求。嵌套且缩进的 `array` 不应触发新事件，
+不同文件或服务绝不合并。详细边界以[格式规则](host-log-format-rules.md)为准。
+
+虚线不能独立作为业务日志。仅过滤纯空白及只含至少五个 `-` 或 `=` 的格式事件，
+保留正文内部内容，并单独解释 `drop_formatting_noise` 的 intentional 计数。
+不要通过扩大丢弃正则来掩盖错误的多行边界。
+
+优先用 JSON 解析器处理合法 JSON，解析失败后只剥离已经确认的旧 message 包装。
+正常长堆栈不按固定行数拆分。物理行上限、序列化大小和显式截断仍然有效，不能把
+正常长日志回归通过解释成所有超大日志无损。
+
+隔离回放应复用实际每台主机的处理拓扑。同类样本共用格式处理链，避免给每个样本
+文件创建独立 transform 而人为放大内存。隔离测试 OOM 时先核对拓扑与内存构成，
+不能直接移除生产资源边界。需要验证的行为包括重启恢复、轮转、跨文件隔离、正文
+内容、深层目录、脱敏和纯分隔线为零；测试入口见文末。
+
+## 4. 正文从采集到复制 JSON 的完整契约
+
+```text
+原始文件 -> 解析/多行/脱敏 -> Kafka message
+         -> consumer: ._msg = string!(del(.message))
+         -> VictoriaLogs _msg
+         -> 明细查询: | copy _msg as message -> Grafana labels.message
+```
+
+Kafka 与 VictoriaLogs 各只存一份正文，复制别名只出现在最多 500 行的明细查询。
+顶部 `message` 变量通过 `_msg:$message` 搜索正文，原生 Filters 负责 `file` 等字段。
+趋势和统计无需复制 message。不要把整个结构化事件重新编码进 message。
+
+只看行数、HTTP 200 或容器 Running 无法发现正文映射错误。每种格式都要核对一条
+真实事件的脱敏正文、换行、业务时间、项目和服务，并用正文片段再次搜索同一记录。
+新日志不应含 `missing _msg field` 占位文本。历史错误映射记录不会因修复消费者而
+自动恢复；排查时检查历史 `message` 字段，不为修复显示而重置全部 offset 或重放
+全部 Topic。历史数据修复必须另行评估重复入库和成本。
+
+## 5. 首次迁移与日常恢复必须分开
+
+1. 备份旧 Filebeat 配置、registry、unit、版本及可执行文件，生成 SHA-256。
+2. 准备已校验的 Harbor 固定版本镜像、独立项目身份及消费者，生成候选配置。
+3. 使用目标机器的 Compose 版本展开候选，再用同版本 Vector 隔离校验与回放。
+4. 仅在允许少量日志丢失的首次窗口使用 `--initial-tail`，小范围观察后逐机切换。
+5. 优雅停止采集器，保留已有 checkpoint；为已存在但尚无位置的文件执行一次性
+   EOF 初始化，再以同一 source ID、fingerprint、state 切回 `read_from: beginning`。
+6. 核对真实 Kafka committed/end offset、实际业务日志、轮转恢复和资源，再停止、
+   禁用并卸载对应 Filebeat 包。每台保留回滚归档与完成时间。
+
+静默文件可能在尚无新事件时未生成 EOF checkpoint，不能认为短暂运行 initial-tail
+已经持久化所有文件位置。EOF 工具仅在采集器停止时使用，device/inode/size 来自
+目标机。日常升级、重启或恢复不得再次跳到 EOF，也不能清空 state。
+
+持久化在 Compose 当前目录的子目录中。采集端使用 `/data/vector/`，项目消费者
+使用独立目录，数据盘路径和容量先核实。回滚保留 Vector state、Kafka 消息及旧
+registry；可能重复的时间窗需记录。旧 ELK、Redis 和历史数据的退役另行安排。
+
+### 老环境的部署细节
+
+- Harbor 域名证书正常不代表认证入口正常，认证 realm 也可能指向不匹配的地址。
+  无法直接拉取时传输受控主机验证过的镜像归档，记录源 digest、image ID 与实际
+  传输归档的 SHA-256。不同归档的 tag 元数据可能不同，不能只比较另一份归档的哈希。
+  不通过关闭 TLS 校验或重启 Docker daemon 绕过问题。
+- 通过 SSH `bash -s` 运行部署脚本时，交互式子命令可能消耗后续脚本的标准输入。
+  不需要交互的容器校验使用 `</dev/null`，检查退出状态以及后续步骤的实际结果。
+- 老 Compose 的一次性 `run` 可能注入与 host network 不兼容的 links。离线语法校验
+  可用独立 `docker run --network none` 挂载候选执行 `vector validate --no-environment`；
+  该检查不证明 Kafka、密码和后端可达，运行后的端到端验收仍须执行。
+
+## 6. Filters 固定显示，沿用 Grafana 原生能力
+
+日志详情加号自动出现的 Filters 是 Grafana 的 ad hoc 变量。将它作为空条件、可见的
+固定变量保存到 Dashboard，即可在首次打开和清空条件后继续显示，无需新增筛选面板。
+
+生成源为 `scripts/render-vvg-message-filter.mjs`。保持唯一的 `Filters`，绑定
+`victorialogs-ds`，使用 `type: adhoc`、`hide: 0`、空 `filters/baseFilters`、
+`allowCustomValue: true` 和 `skipUrlSync: false`。字段条件由数据源插件应用于明细、
+统计和 hits 趋势；不要再向四条查询拼接自制 raw 字段表达式。
+
+![常驻原生 Filters，仅保留筛选栏](images/vvg-native-filters-bar.png)
+
+验收必须从不带旧 Filters URL 参数的页面开始：控件已经显示；添加不可能匹配的
+`file` 条件后，两个统计为零，明细和趋势无数据；清空后结果恢复且控件仍在；刷新
+及复制 URL 可以恢复条件；日志详情加减号继续更新同一控件。原生 Filters 自行清空，
+message 多条件面板的 Reset 只重置自己的条件，二者不互相代替。
+
+Dashboard 变更通过 API 更新定义，不重启 Grafana 或采集器。测试和生产沿用相同
+生成逻辑，最后恢复最近 15 分钟、零字段条件、零 message 多条件、自动刷新关闭。
+
+## 7. 趋势波峰与链路健康分开验证
+
+周期性波峰首先按项目、服务、level 缩小范围，对照源文件业务时间的同时间桶计数。
+PHP SQL 调试或定时任务可以产生周期性输出，但图形相似不能单独证明链路正常。
+若 Kafka lag、buffer 和事件到达延迟同时增长，则继续排查生产、消费和后端写入；
+若源文件本身具有相同周期且这些指标正常，再判断为业务输出节奏。
+
+保留 `hits/logsVolume`、按 level 分组、`maxDataPoints: 100` 和 `barWidthFactor: 0.6`。
+不要仅为消除波峰改变采样、隐藏 debug 或关闭应用 SQL 日志。
+
+指标能由中心拉取时使用 pull；受网络限制时可由现有 Vector 每 15 秒推送到组织
+已有的 Remote Write 接收端。推送使用独立有界指标队列，不增加项目消费者。
+pull 的 `up` 与 push 序列新鲜度分别验收，删除重复不可达的 scrape target。
+仓库有告警模板不等于规则已启用，必须在目标监控系统核对规则和通知路由。
+
+## 8. 交付检查
+
+```bash
+node scripts/render-vvg-message-filter.mjs
+node scripts/validate-vvg-message-filter.mjs
+bash scripts/validate-configs.sh --static
+python3 scripts/test-host-log-runtime.py
+git diff --check
+```
+
+静态检查包含生成配置和单元回归；运行回归需要 Docker，在隔离环境执行。
+配置、规则、合成测试、文档及已脱敏截图一起交付。PR 检查通过后合并，再针对实际
+main 提交重验并发布 Release。Release 不等于重新部署生产；部署版本与实时健康
+必须另取现场证据，不能用历史记录代替。

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,55 @@
+# v0.7.0 - 多项目主机日志迁移与原生 Filters
+
+本版本将传统 Java/PHP 文件日志接入 Vector -> AutoMQ -> VictoriaLogs，并将原生
+Filters 固定在日志大屏顶部。包含从 v0.6.0 之后合并的主机采集、多项目规范、指标
+推送、PHP 服务归并及字段过滤能力；不升级既有 Grafana、VictoriaLogs 或 AutoMQ 镜像。
+
+## 主要变化
+
+- 新增 Compose 主机采集路线、清单生成器、项目初始化脚本及回归测试。每项目一个
+  Topic、固定消费者组和一个消费者，磁盘缓冲与 checkpoint 保留在部署目录。
+- 网大APP与老教务系统 PHP 使用独立项目标签。PHP 服务统一 `php_` 前缀，后台/API
+  共用业务服务名；共享 NFS 文件指定一个采集所有者，避免多主机重复读取。
+- 按真实格式合并 Java 堆栈、ThinkPHP 请求、XML、数组与 CLI 输出，递归覆盖确认的
+  日志目录，过滤独立分隔线，保留正文并排除 runtime 中的缓存和业务账号文件。
+- 统一 Kafka `message` 到 VictoriaLogs `_msg`；明细查询临时复制 `message` 字段，
+  支持展开和复制 JSON 排查，持久化不保存双份正文。
+- 顶部常驻 Grafana 原生 Filters，可直接筛选 `file` 等字段，清空后保留入口，支持
+  URL 恢复和日志详情加减号。message 多条件 Apply/Reset 维持原行为。
+- 受网络限制的采集端可通过现有 Vector 推送运行指标，使用独立有界队列，无需
+  增加消费者或监控进程。
+
+## 升级与维护
+
+先阅读[迁移实践](../host-log-migration-lessons.md)，再按
+[Compose 主机路线](../../docker-compose/vector/host-automq/README.md)盘点和生成配置。
+使用已验证的 Harbor 精确版本镜像；真实地址、身份、清单和备份仅保存于受控环境。
+
+首次迁移允许跳过旧内容时才使用 initial-tail 与一次性 EOF 工具。日常重启使用
+持久 checkpoint，保持 source ID、fingerprint 和 state。新项目按
+[项目规范](../log-project-naming-and-labels.md)登记，不按服务增加消费者。
+
+Dashboard 从生成器发布，保留 UID、datasource、最近 15 分钟、明细 500 行和 hits
+趋势基线。只更新 Dashboard 定义时不需要重启 Grafana。原生 Filters 的说明与已
+脱敏截图见[大屏指南](../grafana-victorialogs-log-search-dashboard-guide.md)。
+
+## 边界与回滚
+
+- CCE 采集和 Nginx 日志不属于主机迁移改动；旧 ELK、Redis 与历史数据不自动退役。
+- 当前接受的单节点 AutoMQ 不是高可用架构；有界缓冲及超大事件截断仍需监控，
+  正常长堆栈完整不代表所有超大日志无损。
+- 服务新标签和正文映射修复作用于新日志，不自动改写历史记录或重放全部 Topic。
+- 回滚使用对应环境的配置、Filebeat 和 Dashboard 备份，保留 Vector state、Kafka
+  消息及旧 registry，并记录可能重复或丢失的迁移时间窗。
+
+## 验证范围
+
+仓库门禁包含生成器防漂移、Dashboard 过滤和查询基线、Compose/Vector 配置校验，
+以及主机格式、轮转、checkpoint 恢复、脱敏和正常长堆栈的合成回归。
+真实业务正文、服务器清单和运行快照不随 Release 发布。Release 发布流程须确认
+PR 与合并后 main 的检查成功，并将标签指向该已验证提交。
+
+功能 PR：[主机迁移 #29](https://github.com/seaworld008/vvg-logs-system/pull/29)、
+[指标推送 #30](https://github.com/seaworld008/vvg-logs-system/pull/30)、
+[PHP 服务统一 #31](https://github.com/seaworld008/vvg-logs-system/pull/31)、
+[原生 Filters #32](https://github.com/seaworld008/vvg-logs-system/pull/32)。


### PR DESCRIPTION
今天的主机日志迁移与原生 Filters 能力已在 #29–#32 合并，但来源盘点、共享目录、首次 EOF、正文验收和旧环境兼容经验分散在多个手册中。本 PR 将这些决定整理为可执行的迁移实践，方便后续项目接入和维护。

- 新增主机迁移实践，明确 PHP 后台/API 共用服务名、NFS 单点采集、runtime 目录分类、多行格式回放、正文映射和原生 Filters 验收。
- 在 AGENTS 与文档入口增加维护约束，修正文档中的 message 变量名、消费者独立目录和截断前大小的含义。
- 增加 v0.7.0 发布说明，汇总 v0.6.0 之后已合并的功能、升级步骤及回滚边界。

本 PR 只修改文档，不改变生产配置或重启服务。复用已有脱敏筛选栏截图，不包含凭据、服务器清单、真实内网地址或原始业务日志。

验证：Dashboard 生成器无内容漂移；message filter 校验、静态配置校验、31 项单元测试、11 个新增文档链接及 git diff --check 通过。Compose/Vector 容器运行回归由本 PR 的 GitHub Actions 执行；全部通过后合并，并在实际 main 再验证后发布 v0.7.0。
